### PR TITLE
READMEs simplified and focused on the value of each example

### DIFF
--- a/plugins/basic-esnext-a2ab62/README.md
+++ b/plugins/basic-esnext-a2ab62/README.md
@@ -7,31 +7,11 @@
 | [📁](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/basic-esnext-a2ab62) | Basic ESNext                                                              | <small><code><a href="https://github.com/WordPress/block-development-examples/wiki/03-Tags#minimal">MINIMAL</a></code></small> | `a2ab62`                                                                                                                                     | [📦](https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/basic-esnext-a2ab62.zip "Install the plugin using this zip and activate it. Then use the ID of the block (a2ab62) to find it and add it to a post to see it in action") | [![](https://raw.githubusercontent.com/WordPress/block-development-examples/trunk/assets/icon-wp.svg)](https://playground.wordpress.net/#%7B%22landingPage%22:%22/wp-admin/plugins.php%22,%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22mkdir%22,%22path%22:%22/downloads%22%7D,%7B%22step%22:%22writeFile%22,%22path%22:%22/downloads/plugin.zip%22,%22data%22:%7B%22resource%22:%22url%22,%22url%22:%22https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/basic-esnext-a2ab62.zip%22,%22caption%22:%22Downloading%20plugin...%22%7D%7D,%7B%22step%22:%22installPlugin%22,%22pluginZipFile%22:%7B%22resource%22:%22vfs%22,%22path%22:%22/downloads/plugin.zip%22%7D%7D%5D%7D "Use the ID of the block (a2ab62) to find it and add it to a post to see it in action") |
 <!-- @TABLE EXAMPLES END -->
 
-## Start Guide
+The goal of this example is to showcase...
 
-#### 1. Install dependencies
+> **Note**
+> Check the [Start Guide for local development with the examples](https://github.com/WordPress/block-development-examples/wiki/02-Examples#start-guide-for-local-development-with-the-examples)
 
-Check the [Repo Commands > Dependencies](../../DEVELOPMENT.md#dependencies) instructions for this repo
+## Understanding the Example Code
 
-#### 2. Generate the build
-
-Once the dependencies are installed (a `node_modules` folder should have been created), we should [launch the build process](../../DEVELOPMENT.md#build-process) to get the final version of the block that can be used from WordPress.
-
-#### 3. Use it in a WordPress
-
-Check the [WordPress Local Development Environment](../../DEVELOPMENT.md#wordpress-local-development-environment) instructions for this repo.
-
-<details>
-  <summary><em>If you have a local WordPress installation already running, you can clone the repo inside the <code>plugins</code> folder of that installation and check the example there</em></summary>
-<br>
-<p>If you do that, you'll need to do the following</p>
-<ul>
-<li>Remove any <code>node_modules</code> folder inside this folder</li>
-<li>Run <code>npm install</code> to install the dependencies</li>
-<li>Run <code>npm build</code> to generate the "build" version of the blocks</li>
-<li>Activate the plugin in your own WordPress installation</li>
-<ul>
-</details>
-<br>
-
-At this point you should be able to insert the custom blocks into any post (after activating the plugin) of your WordPress installation, and see how it behaves in the frontend when published.
+...write description...

--- a/plugins/block-dynamic-rendering-64756b/README.md
+++ b/plugins/block-dynamic-rendering-64756b/README.md
@@ -7,46 +7,11 @@
 | [📁](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/block-dynamic-rendering-64756b) | Basic Block with Dynamic Rendering                                        | <small><code><a href="https://github.com/WordPress/block-development-examples/wiki/03-Tags#dynamic-rendering">DYNAMIC RENDERING</a></code></small>, <small><code><a href="https://github.com/WordPress/block-development-examples/wiki/03-Tags#create-block">CREATE BLOCK</a></code></small> | `64756b`                                                                                                                                     | [📦](https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/block-dynamic-rendering-64756b.zip "Install the plugin using this zip and activate it. Then use the ID of the block (64756b) to find it and add it to a post to see it in action") | [![](https://raw.githubusercontent.com/WordPress/block-development-examples/trunk/assets/icon-wp.svg)](https://playground.wordpress.net/#%7B%22landingPage%22:%22/wp-admin/plugins.php%22,%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22mkdir%22,%22path%22:%22/downloads%22%7D,%7B%22step%22:%22writeFile%22,%22path%22:%22/downloads/plugin.zip%22,%22data%22:%7B%22resource%22:%22url%22,%22url%22:%22https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/block-dynamic-rendering-64756b.zip%22,%22caption%22:%22Downloading%20plugin...%22%7D%7D,%7B%22step%22:%22installPlugin%22,%22pluginZipFile%22:%7B%22resource%22:%22vfs%22,%22path%22:%22/downloads/plugin.zip%22%7D%7D%5D%7D "Use the ID of the block (64756b) to find it and add it to a post to see it in action") |
 <!-- @TABLE EXAMPLES END -->
 
-Basic block that shows how to use of dynamic rendering in a block.
-
-
-## Start Guide
-
-The examples in this repo require these three steps to see them in action:
-
-1. Install dependencies
-2. Generate the build
-3. Use it in a WordPress installation
-
-The way to manage the first two steps will be different depending on the context you're using this example.
+The goal of this example is to showcase the implementation of blocks with dynamic rendering.
 
 > **Note**
-> At the [WIKI of this repo](https://github.com/WordPress/block-development-examples/wiki) you have the documentation for the examples on this repo
+> Check the [Start Guide for local development with the examples](https://github.com/WordPress/block-development-examples/wiki/02-Examples#start-guide-for-local-development-with-the-examples)
 
+## Understanding the Example Code
 
-### As an example inside this monorepo
-
-The quickest way to have access to all the examples is clone this repository and check out the examples locally.
-
-Check the [05 Development > Repo Commands > Dependencies](https://github.com/WordPress/block-development-examples/wiki/05-Development#dependencies) instructions for this repo to install the dependencies of this example.
-
-Once the depencies are installed (a `node_modules` folder should have been created), [launch the build process](https://github.com/WordPress/block-development-examples/wiki/05-Development#build-process) to get the final version of the block that can be used in WordPress. 
-
-Check the [WordPress Local Development Environment](https://github.com/WordPress/block-development-examples/wiki/05-Development#wordpress-local-development-environment) to learn how to quickly get your local WordPress installation to see this example.
-
-### As an isolated example on your own WordPress installation
-
-If you have a local WordPress installation already running, you can also put the plugin folders of the examples you're interested in (by copying and pasting, from the zips...) inside the `plugins` folder of that installation and check the examples there.
-
-If you do that, you'll need to do the following
-
-- Remove any `node_modules` folder inside this folder
-- Run `npm install` to install the dependencies
-- Run `npm build` to generate the "build" version of the blocks
-- Activate the plugin in your own WordPress installation
-
-At this point you should be able to insert the custom blocks into any post (after activating the plugin) of your WordPress installation, and see how it behaves in the frontend when published.
-
-You can also run `npm start` from this folder to generate a development mode "build" version everytime a change in the code is detected (saved) inside this folder.
-
-
+...write description...

--- a/plugins/block-static-rendering-b16608/README.md
+++ b/plugins/block-static-rendering-b16608/README.md
@@ -7,46 +7,13 @@
 | [📁](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/block-static-rendering-b16608) | Block with Static Rendering                                               | <small><code><a href="https://github.com/WordPress/block-development-examples/wiki/03-Tags#static-rendering">STATIC RENDERING</a></code></small>, <small><code><a href="https://github.com/WordPress/block-development-examples/wiki/03-Tags#create-block">CREATE BLOCK</a></code></small> | `b16608`                                                                                                                                     | [📦](https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/block-static-rendering-b16608.zip "Install the plugin using this zip and activate it. Then use the ID of the block (b16608) to find it and add it to a post to see it in action") | [![](https://raw.githubusercontent.com/WordPress/block-development-examples/trunk/assets/icon-wp.svg)](https://playground.wordpress.net/#%7B%22landingPage%22:%22/wp-admin/plugins.php%22,%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22mkdir%22,%22path%22:%22/downloads%22%7D,%7B%22step%22:%22writeFile%22,%22path%22:%22/downloads/plugin.zip%22,%22data%22:%7B%22resource%22:%22url%22,%22url%22:%22https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/block-static-rendering-b16608.zip%22,%22caption%22:%22Downloading%20plugin...%22%7D%7D,%7B%22step%22:%22installPlugin%22,%22pluginZipFile%22:%7B%22resource%22:%22vfs%22,%22path%22:%22/downloads/plugin.zip%22%7D%7D%5D%7D "Use the ID of the block (b16608) to find it and add it to a post to see it in action") |
 <!-- @TABLE EXAMPLES END -->
 
-Basic block that shows how to use of static rendering in a block.
-
-
-## Start Guide
-
-The examples in this repo require these three steps to see them in action:
-
-1. Install dependencies
-2. Generate the build
-3. Use it in a WordPress installation
-
-The way to manage the first two steps will be different depending on the context you're using this example.
+The goal of this example is to showcase the implementation of a block with static rendering.
 
 > **Note**
-> At the [WIKI of this repo](https://github.com/WordPress/block-development-examples/wiki) you have the documentation for the examples on this repo
+> Check the [Start Guide for local development with the examples](https://github.com/WordPress/block-development-examples/wiki/02-Examples#start-guide-for-local-development-with-the-examples)
 
+## Understanding the Example Code
 
-### As an example inside this monorepo
-
-The quickest way to have access to all the examples is clone this repository and check out the examples locally.
-
-Check the [05 Development > Repo Commands > Dependencies](https://github.com/WordPress/block-development-examples/wiki/05-Development#dependencies) instructions for this repo to install the dependencies of this example.
-
-Once the depencies are installed (a `node_modules` folder should have been created), [launch the build process](https://github.com/WordPress/block-development-examples/wiki/05-Development#build-process) to get the final version of the block that can be used in WordPress. 
-
-Check the [WordPress Local Development Environment](https://github.com/WordPress/block-development-examples/wiki/05-Development#wordpress-local-development-environment) to learn how to quickly get your local WordPress installation to see this example.
-
-### As an isolated example on your own WordPress installation
-
-If you have a local WordPress installation already running, you can also put the plugin folders of the examples you're interested in (by copying and pasting, from the zips...) inside the `plugins` folder of that installation and check the examples there.
-
-If you do that, you'll need to do the following
-
-- Remove any `node_modules` folder inside this folder
-- Run `npm install` to install the dependencies
-- Run `npm build` to generate the "build" version of the blocks
-- Activate the plugin in your own WordPress installation
-
-At this point you should be able to insert the custom blocks into any post (after activating the plugin) of your WordPress installation, and see how it behaves in the frontend when published.
-
-You can also run `npm start` from this folder to generate a development mode "build" version everytime a change in the code is detected (saved) inside this folder.
+...write description...
 
 

--- a/plugins/block-supports-6aa4dd/README.md
+++ b/plugins/block-supports-6aa4dd/README.md
@@ -7,43 +7,13 @@
 | [📁](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/block-supports-6aa4dd) | Block Supports                                                            | <small><code><a href="https://github.com/WordPress/block-development-examples/wiki/03-Tags#supports">SUPPORTS</a></code></small> | `6aa4dd`                                                                                                                                     | [📦](https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/block-supports-6aa4dd.zip "Install the plugin using this zip and activate it. Then use the ID of the block (6aa4dd) to find it and add it to a post to see it in action") | [![](https://raw.githubusercontent.com/WordPress/block-development-examples/trunk/assets/icon-wp.svg)](https://playground.wordpress.net/#%7B%22landingPage%22:%22/wp-admin/plugins.php%22,%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22mkdir%22,%22path%22:%22/downloads%22%7D,%7B%22step%22:%22writeFile%22,%22path%22:%22/downloads/plugin.zip%22,%22data%22:%7B%22resource%22:%22url%22,%22url%22:%22https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/block-supports-6aa4dd.zip%22,%22caption%22:%22Downloading%20plugin...%22%7D%7D,%7B%22step%22:%22installPlugin%22,%22pluginZipFile%22:%7B%22resource%22:%22vfs%22,%22path%22:%22/downloads/plugin.zip%22%7D%7D%5D%7D "Use the ID of the block (6aa4dd) to find it and add it to a post to see it in action") |
 <!-- @TABLE EXAMPLES END -->
 
-## Start Guide
-
-The examples in this repo require these three steps to see them in action:
-
-1. Install dependencies
-2. Generate the build
-3. Use it in a WordPress installation
-
-The way to manage the first two steps will be different depending on the context you're using this example.
+The goal of this example is to showcase the implementation of a block with `supports`
 
 > **Note**
-> At the [WIKI of this repo](https://github.com/WordPress/block-development-examples/wiki) you have the documentation for the examples on this repo
+> Check the [Start Guide for local development with the examples](https://github.com/WordPress/block-development-examples/wiki/02-Examples#start-guide-for-local-development-with-the-examples)
 
+## Understanding the Example Code
 
-### As an example inside this monorepo
-
-The quickest way to have access to all the examples is clone this repository and check out the examples locally.
-
-Check the [05 Development > Repo Commands > Dependencies](https://github.com/WordPress/block-development-examples/wiki/05-Development#dependencies) instructions for this repo to install the dependencies of this example.
-
-Once the depencies are installed (a `node_modules` folder should have been created), [launch the build process](https://github.com/WordPress/block-development-examples/wiki/05-Development#build-process) to get the final version of the block that can be used in WordPress. 
-
-Check the [WordPress Local Development Environment](https://github.com/WordPress/block-development-examples/wiki/05-Development#wordpress-local-development-environment) to learn how to quickly get your local WordPress installation to see this example.
-
-### As an isolated example on your own WordPress installation
-
-If you have a local WordPress installation already running, you can also put the plugin folders of the examples you're interested in (by copying and pasting, from the zips...) inside the `plugins` folder of that installation and check the examples there.
-
-If you do that, you'll need to do the following
-
-- Remove any `node_modules` folder inside this folder
-- Run `npm install` to install the dependencies
-- Run `npm build` to generate the "build" version of the blocks
-- Activate the plugin in your own WordPress installation
-
-At this point you should be able to insert the custom blocks into any post (after activating the plugin) of your WordPress installation, and see how it behaves in the frontend when published.
-
-You can also run `npm start` from this folder to generate a development mode "build" version everytime a change in the code is detected (saved) inside this folder.
+...write description...
 
 

--- a/plugins/controls-a9cfe0/README.md
+++ b/plugins/controls-a9cfe0/README.md
@@ -7,43 +7,11 @@
 | [📁](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/controls-a9cfe0) | Controls                                                                  |      | `a9cfe0`                                                                                                                                     | [📦](https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/controls-a9cfe0.zip "Install the plugin using this zip and activate it. Then use the ID of the block (a9cfe0) to find it and add it to a post to see it in action") | [![](https://raw.githubusercontent.com/WordPress/block-development-examples/trunk/assets/icon-wp.svg)](https://playground.wordpress.net/#%7B%22landingPage%22:%22/wp-admin/plugins.php%22,%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22mkdir%22,%22path%22:%22/downloads%22%7D,%7B%22step%22:%22writeFile%22,%22path%22:%22/downloads/plugin.zip%22,%22data%22:%7B%22resource%22:%22url%22,%22url%22:%22https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/controls-a9cfe0.zip%22,%22caption%22:%22Downloading%20plugin...%22%7D%7D,%7B%22step%22:%22installPlugin%22,%22pluginZipFile%22:%7B%22resource%22:%22vfs%22,%22path%22:%22/downloads/plugin.zip%22%7D%7D%5D%7D "Use the ID of the block (a9cfe0) to find it and add it to a post to see it in action") |
 <!-- @TABLE EXAMPLES END -->
 
-## Start Guide
-
-The examples in this repo require these three steps to see them in action:
-
-1. Install dependencies
-2. Generate the build
-3. Use it in a WordPress installation
-
-The way to manage the first two steps will be different depending on the context you're using this example.
+The goal of this example is to showcase...
 
 > **Note**
-> At the [WIKI of this repo](https://github.com/WordPress/block-development-examples/wiki) you have the documentation for the examples on this repo
+> Check the [Start Guide for local development with the examples](https://github.com/WordPress/block-development-examples/wiki/02-Examples#start-guide-for-local-development-with-the-examples)
 
+## Understanding the Example Code
 
-### As an example inside this monorepo
-
-The quickest way to have access to all the examples is clone this repository and check out the examples locally.
-
-Check the [05 Development > Repo Commands > Dependencies](https://github.com/WordPress/block-development-examples/wiki/05-Development#dependencies) instructions for this repo to install the dependencies of this example.
-
-Once the depencies are installed (a `node_modules` folder should have been created), [launch the build process](https://github.com/WordPress/block-development-examples/wiki/05-Development#build-process) to get the final version of the block that can be used in WordPress. 
-
-Check the [WordPress Local Development Environment](https://github.com/WordPress/block-development-examples/wiki/05-Development#wordpress-local-development-environment) to learn how to quickly get your local WordPress installation to see this example.
-
-### As an isolated example on your own WordPress installation
-
-If you have a local WordPress installation already running, you can also put the plugin folders of the examples you're interested in (by copying and pasting, from the zips...) inside the `plugins` folder of that installation and check the examples there.
-
-If you do that, you'll need to do the following
-
-- Remove any `node_modules` folder inside this folder
-- Run `npm install` to install the dependencies
-- Run `npm build` to generate the "build" version of the blocks
-- Activate the plugin in your own WordPress installation
-
-At this point you should be able to insert the custom blocks into any post (after activating the plugin) of your WordPress installation, and see how it behaves in the frontend when published.
-
-You can also run `npm start` from this folder to generate a development mode "build" version everytime a change in the code is detected (saved) inside this folder.
-
-
+...write description...

--- a/plugins/dynamic-block-b0bce7/README.md
+++ b/plugins/dynamic-block-b0bce7/README.md
@@ -7,43 +7,11 @@
 | [📁](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/dynamic-block-b0bce7) | Dynamic Block                                                             | <small><code><a href="https://github.com/WordPress/block-development-examples/wiki/03-Tags#dynamic-rendering">DYNAMIC RENDERING</a></code></small> | `b0bce7`                                                                                                                                     | [📦](https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/dynamic-block-b0bce7.zip "Install the plugin using this zip and activate it. Then use the ID of the block (b0bce7) to find it and add it to a post to see it in action") | [![](https://raw.githubusercontent.com/WordPress/block-development-examples/trunk/assets/icon-wp.svg)](https://playground.wordpress.net/#%7B%22landingPage%22:%22/wp-admin/plugins.php%22,%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22mkdir%22,%22path%22:%22/downloads%22%7D,%7B%22step%22:%22writeFile%22,%22path%22:%22/downloads/plugin.zip%22,%22data%22:%7B%22resource%22:%22url%22,%22url%22:%22https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/dynamic-block-b0bce7.zip%22,%22caption%22:%22Downloading%20plugin...%22%7D%7D,%7B%22step%22:%22installPlugin%22,%22pluginZipFile%22:%7B%22resource%22:%22vfs%22,%22path%22:%22/downloads/plugin.zip%22%7D%7D%5D%7D "Use the ID of the block (b0bce7) to find it and add it to a post to see it in action") |
 <!-- @TABLE EXAMPLES END -->
 
-## Start Guide
-
-The examples in this repo require these three steps to see them in action:
-
-1. Install dependencies
-2. Generate the build
-3. Use it in a WordPress installation
-
-The way to manage the first two steps will be different depending on the context you're using this example.
+The goal of this example is to showcase...
 
 > **Note**
-> At the [WIKI of this repo](https://github.com/WordPress/block-development-examples/wiki) you have the documentation for the examples on this repo
+> Check the [Start Guide for local development with the examples](https://github.com/WordPress/block-development-examples/wiki/02-Examples#start-guide-for-local-development-with-the-examples)
 
+## Understanding the Example Code
 
-### As an example inside this monorepo
-
-The quickest way to have access to all the examples is clone this repository and check out the examples locally.
-
-Check the [05 Development > Repo Commands > Dependencies](https://github.com/WordPress/block-development-examples/wiki/05-Development#dependencies) instructions for this repo to install the dependencies of this example.
-
-Once the depencies are installed (a `node_modules` folder should have been created), [launch the build process](https://github.com/WordPress/block-development-examples/wiki/05-Development#build-process) to get the final version of the block that can be used in WordPress. 
-
-Check the [WordPress Local Development Environment](https://github.com/WordPress/block-development-examples/wiki/05-Development#wordpress-local-development-environment) to learn how to quickly get your local WordPress installation to see this example.
-
-### As an isolated example on your own WordPress installation
-
-If you have a local WordPress installation already running, you can also put the plugin folders of the examples you're interested in (by copying and pasting, from the zips...) inside the `plugins` folder of that installation and check the examples there.
-
-If you do that, you'll need to do the following
-
-- Remove any `node_modules` folder inside this folder
-- Run `npm install` to install the dependencies
-- Run `npm build` to generate the "build" version of the blocks
-- Activate the plugin in your own WordPress installation
-
-At this point you should be able to insert the custom blocks into any post (after activating the plugin) of your WordPress installation, and see how it behaves in the frontend when published.
-
-You can also run `npm start` from this folder to generate a development mode "build" version everytime a change in the code is detected (saved) inside this folder.
-
-
+...write description...

--- a/plugins/editable-block-1b8c51/README.md
+++ b/plugins/editable-block-1b8c51/README.md
@@ -7,46 +7,11 @@
 | [📁](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/editable-block-1b8c51) | Block Editable                                                            |      | `1b8c51`                                                                                                                                     | [📦](https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/editable-block-1b8c51.zip "Install the plugin using this zip and activate it. Then use the ID of the block (1b8c51) to find it and add it to a post to see it in action") | [![](https://raw.githubusercontent.com/WordPress/block-development-examples/trunk/assets/icon-wp.svg)](https://playground.wordpress.net/#%7B%22landingPage%22:%22/wp-admin/plugins.php%22,%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22mkdir%22,%22path%22:%22/downloads%22%7D,%7B%22step%22:%22writeFile%22,%22path%22:%22/downloads/plugin.zip%22,%22data%22:%7B%22resource%22:%22url%22,%22url%22:%22https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/editable-block-1b8c51.zip%22,%22caption%22:%22Downloading%20plugin...%22%7D%7D,%7B%22step%22:%22installPlugin%22,%22pluginZipFile%22:%7B%22resource%22:%22vfs%22,%22path%22:%22/downloads/plugin.zip%22%7D%7D%5D%7D "Use the ID of the block (1b8c51) to find it and add it to a post to see it in action") |
 <!-- @TABLE EXAMPLES END -->
 
-Basic block that shows how to create a block that is editable. This block also show the use of e2e testing for a block.
-
-
-## Start Guide
-
-The examples in this repo require these three steps to see them in action:
-
-1. Install dependencies
-2. Generate the build
-3. Use it in a WordPress installation
-
-The way to manage the first two steps will be different depending on the context you're using this example.
+The goal of this example is to showcase how to create a block that is editable. This block also show the use of e2e testing for a block.
 
 > **Note**
-> At the [WIKI of this repo](https://github.com/WordPress/block-development-examples/wiki) you have the documentation for the examples on this repo
+> Check the [Start Guide for local development with the examples](https://github.com/WordPress/block-development-examples/wiki/02-Examples#start-guide-for-local-development-with-the-examples)
 
+## Understanding the Example Code
 
-### As an example inside this monorepo
-
-The quickest way to have access to all the examples is clone this repository and check out the examples locally.
-
-Check the [05 Development > Repo Commands > Dependencies](https://github.com/WordPress/block-development-examples/wiki/05-Development#dependencies) instructions for this repo to install the dependencies of this example.
-
-Once the depencies are installed (a `node_modules` folder should have been created), [launch the build process](https://github.com/WordPress/block-development-examples/wiki/05-Development#build-process) to get the final version of the block that can be used in WordPress. 
-
-Check the [WordPress Local Development Environment](https://github.com/WordPress/block-development-examples/wiki/05-Development#wordpress-local-development-environment) to learn how to quickly get your local WordPress installation to see this example.
-
-### As an isolated example on your own WordPress installation
-
-If you have a local WordPress installation already running, you can also put the plugin folders of the examples you're interested in (by copying and pasting, from the zips...) inside the `plugins` folder of that installation and check the examples there.
-
-If you do that, you'll need to do the following
-
-- Remove any `node_modules` folder inside this folder
-- Run `npm install` to install the dependencies
-- Run `npm build` to generate the "build" version of the blocks
-- Activate the plugin in your own WordPress installation
-
-At this point you should be able to insert the custom blocks into any post (after activating the plugin) of your WordPress installation, and see how it behaves in the frontend when published.
-
-You can also run `npm start` from this folder to generate a development mode "build" version everytime a change in the code is detected (saved) inside this folder.
-
-
+...write description...

--- a/plugins/format-api-f14b86/README.md
+++ b/plugins/format-api-f14b86/README.md
@@ -7,45 +7,11 @@
 | [📁](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/format-api-f14b86) | Format API                                                                | <small><code><a href="https://github.com/WordPress/block-development-examples/wiki/03-Tags#no-block">NO BLOCK</a></code></small> | `f14b86`                                                                                                                                     | [📦](https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/format-api-f14b86.zip "") | [![](https://raw.githubusercontent.com/WordPress/block-development-examples/trunk/assets/icon-wp.svg)](https://playground.wordpress.net/#%7B%22landingPage%22:%22/wp-admin/plugins.php%22,%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22mkdir%22,%22path%22:%22/downloads%22%7D,%7B%22step%22:%22writeFile%22,%22path%22:%22/downloads/plugin.zip%22,%22data%22:%7B%22resource%22:%22url%22,%22url%22:%22https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/format-api-f14b86.zip%22,%22caption%22:%22Downloading%20plugin...%22%7D%7D,%7B%22step%22:%22installPlugin%22,%22pluginZipFile%22:%7B%22resource%22:%22vfs%22,%22path%22:%22/downloads/plugin.zip%22%7D%7D%5D%7D "") |
 <!-- @TABLE EXAMPLES END -->
 
-An example of how to define a custom format that is used in the block toolbar.
-
-## Start Guide
-
-The examples in this repo require these three steps to see them in action:
-
-1. Install dependencies
-2. Generate the build
-3. Use it in a WordPress installation
-
-The way to manage the first two steps will be different depending on the context you're using this example.
+The goal of this example is to showcase how to define a custom format that is used in the block toolbar.
 
 > **Note**
-> At the [WIKI of this repo](https://github.com/WordPress/block-development-examples/wiki) you have the documentation for the examples on this repo
+> Check the [Start Guide for local development with the examples](https://github.com/WordPress/block-development-examples/wiki/02-Examples#start-guide-for-local-development-with-the-examples)
 
+## Understanding the Example Code
 
-### As an example inside this monorepo
-
-The quickest way to have access to all the examples is clone this repository and check out the examples locally.
-
-Check the [05 Development > Repo Commands > Dependencies](https://github.com/WordPress/block-development-examples/wiki/05-Development#dependencies) instructions for this repo to install the dependencies of this example.
-
-Once the depencies are installed (a `node_modules` folder should have been created), [launch the build process](https://github.com/WordPress/block-development-examples/wiki/05-Development#build-process) to get the final version of the block that can be used in WordPress. 
-
-Check the [WordPress Local Development Environment](https://github.com/WordPress/block-development-examples/wiki/05-Development#wordpress-local-development-environment) to learn how to quickly get your local WordPress installation to see this example.
-
-### As an isolated example on your own WordPress installation
-
-If you have a local WordPress installation already running, you can also put the plugin folders of the examples you're interested in (by copying and pasting, from the zips...) inside the `plugins` folder of that installation and check the examples there.
-
-If you do that, you'll need to do the following
-
-- Remove any `node_modules` folder inside this folder
-- Run `npm install` to install the dependencies
-- Run `npm build` to generate the "build" version of the blocks
-- Activate the plugin in your own WordPress installation
-
-At this point you should be able to insert the custom blocks into any post (after activating the plugin) of your WordPress installation, and see how it behaves in the frontend when published.
-
-You can also run `npm start` from this folder to generate a development mode "build" version everytime a change in the code is detected (saved) inside this folder.
-
-
+...write description...

--- a/plugins/inner-blocks-dcd824/README.md
+++ b/plugins/inner-blocks-dcd824/README.md
@@ -7,43 +7,11 @@
 | [📁](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/inner-blocks-dcd824) | Inner Blocks                                                              |      | `dcd824`                                                                                                                                     | [📦](https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/inner-blocks-dcd824.zip "Install the plugin using this zip and activate it. Then use the ID of the block (dcd824) to find it and add it to a post to see it in action") | [![](https://raw.githubusercontent.com/WordPress/block-development-examples/trunk/assets/icon-wp.svg)](https://playground.wordpress.net/#%7B%22landingPage%22:%22/wp-admin/plugins.php%22,%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22mkdir%22,%22path%22:%22/downloads%22%7D,%7B%22step%22:%22writeFile%22,%22path%22:%22/downloads/plugin.zip%22,%22data%22:%7B%22resource%22:%22url%22,%22url%22:%22https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/inner-blocks-dcd824.zip%22,%22caption%22:%22Downloading%20plugin...%22%7D%7D,%7B%22step%22:%22installPlugin%22,%22pluginZipFile%22:%7B%22resource%22:%22vfs%22,%22path%22:%22/downloads/plugin.zip%22%7D%7D%5D%7D "Use the ID of the block (dcd824) to find it and add it to a post to see it in action") |
 <!-- @TABLE EXAMPLES END -->
 
-## Start Guide
-
-The examples in this repo require these three steps to see them in action:
-
-1. Install dependencies
-2. Generate the build
-3. Use it in a WordPress installation
-
-The way to manage the first two steps will be different depending on the context you're using this example.
+The goal of this example is to showcase...
 
 > **Note**
-> At the [WIKI of this repo](https://github.com/WordPress/block-development-examples/wiki) you have the documentation for the examples on this repo
+> Check the [Start Guide for local development with the examples](https://github.com/WordPress/block-development-examples/wiki/02-Examples#start-guide-for-local-development-with-the-examples)
 
+## Understanding the Example Code
 
-### As an example inside this monorepo
-
-The quickest way to have access to all the examples is clone this repository and check out the examples locally.
-
-Check the [05 Development > Repo Commands > Dependencies](https://github.com/WordPress/block-development-examples/wiki/05-Development#dependencies) instructions for this repo to install the dependencies of this example.
-
-Once the depencies are installed (a `node_modules` folder should have been created), [launch the build process](https://github.com/WordPress/block-development-examples/wiki/05-Development#build-process) to get the final version of the block that can be used in WordPress. 
-
-Check the [WordPress Local Development Environment](https://github.com/WordPress/block-development-examples/wiki/05-Development#wordpress-local-development-environment) to learn how to quickly get your local WordPress installation to see this example.
-
-### As an isolated example on your own WordPress installation
-
-If you have a local WordPress installation already running, you can also put the plugin folders of the examples you're interested in (by copying and pasting, from the zips...) inside the `plugins` folder of that installation and check the examples there.
-
-If you do that, you'll need to do the following
-
-- Remove any `node_modules` folder inside this folder
-- Run `npm install` to install the dependencies
-- Run `npm build` to generate the "build" version of the blocks
-- Activate the plugin in your own WordPress installation
-
-At this point you should be able to insert the custom blocks into any post (after activating the plugin) of your WordPress installation, and see how it behaves in the frontend when published.
-
-You can also run `npm start` from this folder to generate a development mode "build" version everytime a change in the code is detected (saved) inside this folder.
-
-
+...write description...

--- a/plugins/interactive-blocks-demos-99def1/README.md
+++ b/plugins/interactive-blocks-demos-99def1/README.md
@@ -7,8 +7,7 @@
 | [📁](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/interactive-blocks-demos-99def1) | Interactive Blocks                                                        | <small><code><a href="https://github.com/WordPress/block-development-examples/wiki/03-Tags#interactive-block">INTERACTIVE BLOCK</a></code></small>, <small><code><a href="https://github.com/WordPress/block-development-examples/wiki/03-Tags#multi-block">MULTI BLOCK</a></code></small> | `99def1`                                                                                                                                     | [📦](https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/interactive-blocks-demos-99def1.zip "Install the plugin using this zip and activate it. Then use the ID of the block (99def1) to find it and add it to a post to see it in action") | [![](https://raw.githubusercontent.com/WordPress/block-development-examples/trunk/assets/icon-wp.svg)](https://playground.wordpress.net/#%7B%22landingPage%22:%22/wp-admin/plugins.php%22,%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22mkdir%22,%22path%22:%22/downloads%22%7D,%7B%22step%22:%22writeFile%22,%22path%22:%22/downloads/plugin.zip%22,%22data%22:%7B%22resource%22:%22url%22,%22url%22:%22https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/interactive-blocks-demos-99def1.zip%22,%22caption%22:%22Downloading%20plugin...%22%7D%7D,%7B%22step%22:%22installPlugin%22,%22pluginZipFile%22:%7B%22resource%22:%22vfs%22,%22path%22:%22/downloads/plugin.zip%22%7D%7D%5D%7D "Use the ID of the block (99def1) to find it and add it to a post to see it in action") |
 <!-- @TABLE EXAMPLES END -->
 
-An exploratory plugin for using different ways of creating interactive blocks in [Gutenberg](https://github.com/WordPress/gutenberg).
-
+The goal of this example is to showcase the use of different ways of creating interactive blocks in [Gutenberg](https://github.com/WordPress/gutenberg).
 
 This example shows how to add interactivity to a block using:
 - Alpine
@@ -17,49 +16,14 @@ This example shows how to add interactivity to a block using:
 - Plain JS
 - Web Components
 
-> **Note**
-> This example has been adapted from [the original one](https://github.com/wptrainingteam/interactive-blocks-demos) that was used in the lightning talk **[Creating interactive blocks: old, new, and good ways](https://europe.wordcamp.org/2022/session/lightning-talks/)** at the [WordCamp Europe 2022](https://europe.wordcamp.org/2022/) (see [video](https://www.youtube.com/watch?v=91anxAgQGJw&t=15939s) and [slides](https://github.com/WordPress/block-development-examples/blob/trunk/plugins/interactive-blocks-demos-99def1/assets/interactive-blocks-talk-slides.pdf) of this talk)
-
-
-
-
-## Start Guide
-
-The examples in this repo require these three steps to see them in action:
-
-1. Install dependencies
-2. Generate the build
-3. Use it in a WordPress installation
-
-The way to manage the first two steps will be different depending on the context you're using this example.
+_This example has been adapted from [the original one](https://github.com/wptrainingteam/interactive-blocks-demos) that was used in the lightning talk **[Creating interactive blocks: old, new, and good ways](https://europe.wordcamp.org/2022/session/lightning-talks/)** at the [WordCamp Europe 2022](https://europe.wordcamp.org/2022/) (see [video](https://www.youtube.com/watch?v=91anxAgQGJw&t=15939s) and [slides](https://github.com/WordPress/block-development-examples/blob/trunk/plugins/interactive-blocks-demos-99def1/assets/interactive-blocks-talk-slides.pdf) of this talk)_
 
 > **Note**
-> At the [WIKI of this repo](https://github.com/WordPress/block-development-examples/wiki) you have the documentation for the examples on this repo
+> Check the [Start Guide for local development with the examples](https://github.com/WordPress/block-development-examples/wiki/02-Examples#start-guide-for-local-development-with-the-examples)
 
+## Understanding the Example Code
 
-### As an example inside this monorepo
+...write description...
 
-The quickest way to have access to all the examples is clone this repository and check out the examples locally.
-
-Check the [05 Development > Repo Commands > Dependencies](https://github.com/WordPress/block-development-examples/wiki/05-Development#dependencies) instructions for this repo to install the dependencies of this example.
-
-Once the depencies are installed (a `node_modules` folder should have been created), [launch the build process](https://github.com/WordPress/block-development-examples/wiki/05-Development#build-process) to get the final version of the block that can be used in WordPress. 
-
-Check the [WordPress Local Development Environment](https://github.com/WordPress/block-development-examples/wiki/05-Development#wordpress-local-development-environment) to learn how to quickly get your local WordPress installation to see this example.
-
-### As an isolated example on your own WordPress installation
-
-If you have a local WordPress installation already running, you can also put the plugin folders of the examples you're interested in (by copying and pasting, from the zips...) inside the `plugins` folder of that installation and check the examples there.
-
-If you do that, you'll need to do the following
-
-- Remove any `node_modules` folder inside this folder
-- Run `npm install` to install the dependencies
-- Run `npm build` to generate the "build" version of the blocks
-- Activate the plugin in your own WordPress installation
-
-At this point you should be able to insert the custom blocks into any post (after activating the plugin) of your WordPress installation, and see how it behaves in the frontend when published.
-
-You can also run `npm start` from this folder to generate a development mode "build" version everytime a change in the code is detected (saved) inside this folder.
 
 

--- a/plugins/interactivity-api-block-833d15/README.md
+++ b/plugins/interactivity-api-block-833d15/README.md
@@ -21,43 +21,9 @@ Check the following resources for more info about the Interactivity API:
 - [Proposal: The Interactivity API – A better developer experience in building interactive blocks](https://make.wordpress.org/core/2023/03/30/proposal-the-interactivity-api-a-better-developer-experience-in-building-interactive-blocks/)
 - [“Interactivity API” category](https://github.com/WordPress/gutenberg/discussions/categories/interactivity-api) in Gutenberg repo discussions
 
-## Start Guide
-
-The examples in this repo require these three steps to see them in action:
-
-1. Install dependencies
-2. Generate the build
-3. Use it in a WordPress installation
-
-The way to manage the first two steps will be different depending on the context you're using this example.
-
 > **Note**
-> At the [WIKI of this repo](https://github.com/WordPress/block-development-examples/wiki) you have the documentation for the examples on this repo
+> Check the [Start Guide for local development with the examples](https://github.com/WordPress/block-development-examples/wiki/02-Examples#start-guide-for-local-development-with-the-examples)
 
+## Understanding the Example Code
 
-### As an example inside this monorepo
-
-The quickest way to have access to all the examples is clone this repository and check out the examples locally.
-
-Check the [05 Development > Repo Commands > Dependencies](https://github.com/WordPress/block-development-examples/wiki/05-Development#dependencies) instructions for this repo to install the dependencies of this example.
-
-Once the depencies are installed (a `node_modules` folder should have been created), [launch the build process](https://github.com/WordPress/block-development-examples/wiki/05-Development#build-process) to get the final version of the block that can be used in WordPress. 
-
-Check the [WordPress Local Development Environment](https://github.com/WordPress/block-development-examples/wiki/05-Development#wordpress-local-development-environment) to learn how to quickly get your local WordPress installation to see this example.
-
-### As an isolated example on your own WordPress installation
-
-If you have a local WordPress installation already running, you can also put the plugin folders of the examples you're interested in (by copying and pasting, from the zips...) inside the `plugins` folder of that installation and check the examples there.
-
-If you do that, you'll need to do the following
-
-- Remove any `node_modules` folder inside this folder
-- Run `npm install` to install the dependencies
-- Run `npm build` to generate the "build" version of the blocks
-- Activate the plugin in your own WordPress installation
-
-At this point you should be able to insert the custom blocks into any post (after activating the plugin) of your WordPress installation, and see how it behaves in the frontend when published.
-
-You can also run `npm start` from this folder to generate a development mode "build" version everytime a change in the code is detected (saved) inside this folder.
-
-
+...write description...

--- a/plugins/meta-block-bb1e55/README.md
+++ b/plugins/meta-block-bb1e55/README.md
@@ -7,43 +7,11 @@
 | [📁](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/meta-block-bb1e55) | Meta Block                                                                | <small><code><a href="https://github.com/WordPress/block-development-examples/wiki/03-Tags#meta">META</a></code></small> | `bb1e55`                                                                                                                                     | [📦](https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/meta-block-bb1e55.zip "Install the plugin using this zip and activate it. Then use the ID of the block (bb1e55) to find it and add it to a post to see it in action") | [![](https://raw.githubusercontent.com/WordPress/block-development-examples/trunk/assets/icon-wp.svg)](https://playground.wordpress.net/#%7B%22landingPage%22:%22/wp-admin/plugins.php%22,%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22mkdir%22,%22path%22:%22/downloads%22%7D,%7B%22step%22:%22writeFile%22,%22path%22:%22/downloads/plugin.zip%22,%22data%22:%7B%22resource%22:%22url%22,%22url%22:%22https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/meta-block-bb1e55.zip%22,%22caption%22:%22Downloading%20plugin...%22%7D%7D,%7B%22step%22:%22installPlugin%22,%22pluginZipFile%22:%7B%22resource%22:%22vfs%22,%22path%22:%22/downloads/plugin.zip%22%7D%7D%5D%7D "Use the ID of the block (bb1e55) to find it and add it to a post to see it in action") |
 <!-- @TABLE EXAMPLES END -->
 
-## Start Guide
-
-The examples in this repo require these three steps to see them in action:
-
-1. Install dependencies
-2. Generate the build
-3. Use it in a WordPress installation
-
-The way to manage the first two steps will be different depending on the context you're using this example.
+The goal of this example is to showcase...
 
 > **Note**
-> At the [WIKI of this repo](https://github.com/WordPress/block-development-examples/wiki) you have the documentation for the examples on this repo
+> Check the [Start Guide for local development with the examples](https://github.com/WordPress/block-development-examples/wiki/02-Examples#start-guide-for-local-development-with-the-examples)
 
+## Understanding the Example Code
 
-### As an example inside this monorepo
-
-The quickest way to have access to all the examples is clone this repository and check out the examples locally.
-
-Check the [05 Development > Repo Commands > Dependencies](https://github.com/WordPress/block-development-examples/wiki/05-Development#dependencies) instructions for this repo to install the dependencies of this example.
-
-Once the depencies are installed (a `node_modules` folder should have been created), [launch the build process](https://github.com/WordPress/block-development-examples/wiki/05-Development#build-process) to get the final version of the block that can be used in WordPress. 
-
-Check the [WordPress Local Development Environment](https://github.com/WordPress/block-development-examples/wiki/05-Development#wordpress-local-development-environment) to learn how to quickly get your local WordPress installation to see this example.
-
-### As an isolated example on your own WordPress installation
-
-If you have a local WordPress installation already running, you can also put the plugin folders of the examples you're interested in (by copying and pasting, from the zips...) inside the `plugins` folder of that installation and check the examples there.
-
-If you do that, you'll need to do the following
-
-- Remove any `node_modules` folder inside this folder
-- Run `npm install` to install the dependencies
-- Run `npm build` to generate the "build" version of the blocks
-- Activate the plugin in your own WordPress installation
-
-At this point you should be able to insert the custom blocks into any post (after activating the plugin) of your WordPress installation, and see how it behaves in the frontend when published.
-
-You can also run `npm start` from this folder to generate a development mode "build" version everytime a change in the code is detected (saved) inside this folder.
-
-
+...write description...

--- a/plugins/minimal-block-ca6eda/README.md
+++ b/plugins/minimal-block-ca6eda/README.md
@@ -11,60 +11,16 @@ This example contains a plugin that register a minimal block that has been defin
 
 > [See diagram](https://excalidraw.com/#json=p5GXuqsMjZe7pEJ99-6EM,OuVzzTujO91JYnCSNVwEBg) 
 
+The goal of this example is to showcase...
+
+> **Note**
+> Check the [Start Guide for local development with the examples](https://github.com/WordPress/block-development-examples/wiki/02-Examples#start-guide-for-local-development-with-the-examples)
 
 ## Table of Contents
 
-- [Start Guide](#start-guide)
-  - [1. Install dependencies](#1-install-dependencies)
-  - [2. Generate the build ](#2-generate-the-build)
-  - [3. Use it in your WordPress installation ](#3-use-it-in-your-wordpress-installation)
 - [Anatomy of this block](#anatomy-of-this-block)
   - [The plugin](#the-plugin)   
   - [The block](#the-block) 
-
-
-## Start Guide
-
-The examples in this repo require these three steps to see them in action:
-
-1. Install dependencies
-2. Generate the build
-3. Use it in a WordPress installation
-
-The way to manage the first two steps will be different depending on the context you're using this example.
-
-> **Note**
-> At the [WIKI of this repo](https://github.com/WordPress/block-development-examples/wiki) you have the documentation for the examples on this repo
-
-
-### As an example inside this monorepo
-
-The quickest way to have access to all the examples is clone this repository and check out the examples locally.
-
-Check the [05 Development > Repo Commands > Dependencies](https://github.com/WordPress/block-development-examples/wiki/05-Development#dependencies) instructions for this repo to install the dependencies of this example.
-
-Once the depencies are installed (a `node_modules` folder should have been created), [launch the build process](https://github.com/WordPress/block-development-examples/wiki/05-Development#build-process) to get the final version of the block that can be used in WordPress. 
-
-Check the [WordPress Local Development Environment](https://github.com/WordPress/block-development-examples/wiki/05-Development#wordpress-local-development-environment) to learn how to quickly get your local WordPress installation to see this example.
-
-### As an isolated example on your own WordPress installation
-
-If you have a local WordPress installation already running, you can also put the plugin folders of the examples you're interested in (by copying and pasting, from the zips...) inside the `plugins` folder of that installation and check the examples there.
-
-If you do that, you'll need to do the following
-
-- Remove any `node_modules` folder inside this folder
-- Run `npm install` to install the dependencies
-- Run `npm build` to generate the "build" version of the blocks
-- Activate the plugin in your own WordPress installation
-
-At this point you should be able to insert the custom blocks into any post (after activating the plugin) of your WordPress installation, and see how it behaves in the frontend when published.
-
-You can also run `npm start` from this folder to generate a development mode "build" version everytime a change in the code is detected (saved) inside this folder.
-
-
-
-
 
 ## Anatomy of this block
 

--- a/plugins/minimal-block-no-build-e621a6/README.md
+++ b/plugins/minimal-block-no-build-e621a6/README.md
@@ -9,46 +9,11 @@ This example contains a plugin that register a minimal block that has been defin
 | [📁](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/minimal-block-no-build-e621a6) | Minimal Gutenberg Block (No Build)                                        | <small><code><a href="https://github.com/WordPress/block-development-examples/wiki/03-Tags#minimal">MINIMAL</a></code></small>, <small><code><a href="https://github.com/WordPress/block-development-examples/wiki/03-Tags#no-build">NO BUILD</a></code></small> | `e621a6`                                                                                                                                     | [📦](https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/minimal-block-no-build-e621a6.zip "Install the plugin using this zip and activate it. Then use the ID of the block (e621a6) to find it and add it to a post to see it in action") | [![](https://raw.githubusercontent.com/WordPress/block-development-examples/trunk/assets/icon-wp.svg)](https://playground.wordpress.net/#%7B%22landingPage%22:%22/wp-admin/plugins.php%22,%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22mkdir%22,%22path%22:%22/downloads%22%7D,%7B%22step%22:%22writeFile%22,%22path%22:%22/downloads/plugin.zip%22,%22data%22:%7B%22resource%22:%22url%22,%22url%22:%22https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/minimal-block-no-build-e621a6.zip%22,%22caption%22:%22Downloading%20plugin...%22%7D%7D,%7B%22step%22:%22installPlugin%22,%22pluginZipFile%22:%7B%22resource%22:%22vfs%22,%22path%22:%22/downloads/plugin.zip%22%7D%7D%5D%7D "Use the ID of the block (e621a6) to find it and add it to a post to see it in action") |
 <!-- @TABLE EXAMPLES END -->
 
-## Start Guide
-
-The examples in this repo require these three steps to see them in action:
-
-1. Install dependencies
-2. Generate the build
-3. Use it in a WordPress installation
-
-The way to manage the first two steps will be different depending on the context you're using this example.
+The goal of this example is to showcase...
 
 > **Note**
-> At the [WIKI of this repo](https://github.com/WordPress/block-development-examples/wiki) you have the documentation for the examples on this repo
+> Check the [Start Guide for local development with the examples](https://github.com/WordPress/block-development-examples/wiki/02-Examples#start-guide-for-local-development-with-the-examples)
 
+## Understanding the Example Code
 
-### As an example inside this monorepo
-
-The quickest way to have access to all the examples is clone this repository and check out the examples locally.
-
-Check the [05 Development > Repo Commands > Dependencies](https://github.com/WordPress/block-development-examples/wiki/05-Development#dependencies) instructions for this repo to install the dependencies of this example.
-
-Once the depencies are installed (a `node_modules` folder should have been created), [launch the build process](https://github.com/WordPress/block-development-examples/wiki/05-Development#build-process) to get the final version of the block that can be used in WordPress. 
-
-Check the [WordPress Local Development Environment](https://github.com/WordPress/block-development-examples/wiki/05-Development#wordpress-local-development-environment) to learn how to quickly get your local WordPress installation to see this example.
-
-### As an isolated example on your own WordPress installation
-
-If you have a local WordPress installation already running, you can also put the plugin folders of the examples you're interested in (by copying and pasting, from the zips...) inside the `plugins` folder of that installation and check the examples there.
-
-If you do that, you'll need to do the following
-
-- Remove any `node_modules` folder inside this folder
-- Run `npm install` to install the dependencies
-- Run `npm build` to generate the "build" version of the blocks
-- Activate the plugin in your own WordPress installation
-
-At this point you should be able to insert the custom blocks into any post (after activating the plugin) of your WordPress installation, and see how it behaves in the frontend when published.
-
-You can also run `npm start` from this folder to generate a development mode "build" version everytime a change in the code is detected (saved) inside this folder.
-
-
-
-
-
+...write description...

--- a/plugins/non-block-react-wp-data-56d6f3/README.md
+++ b/plugins/non-block-react-wp-data-56d6f3/README.md
@@ -7,46 +7,11 @@
 | [📁](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/non-block-react-wp-data-56d6f3) | Non-block wp data with React                                              | <small><code><a href="https://github.com/WordPress/block-development-examples/wiki/03-Tags#no-block">NO BLOCK</a></code></small>, <small><code><a href="https://github.com/WordPress/block-development-examples/wiki/03-Tags#wp-data">WP DATA</a></code></small> | `56d6f3`                                                                                                                                     | [📦](https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/non-block-react-wp-data-56d6f3.zip "") | [![](https://raw.githubusercontent.com/WordPress/block-development-examples/trunk/assets/icon-wp.svg)](https://playground.wordpress.net/#%7B%22landingPage%22:%22/wp-admin/plugins.php%22,%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22mkdir%22,%22path%22:%22/downloads%22%7D,%7B%22step%22:%22writeFile%22,%22path%22:%22/downloads/plugin.zip%22,%22data%22:%7B%22resource%22:%22url%22,%22url%22:%22https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/non-block-react-wp-data-56d6f3.zip%22,%22caption%22:%22Downloading%20plugin...%22%7D%7D,%7B%22step%22:%22installPlugin%22,%22pluginZipFile%22:%7B%22resource%22:%22vfs%22,%22path%22:%22/downloads/plugin.zip%22%7D%7D%5D%7D "") |
 <!-- @TABLE EXAMPLES END -->
 
-This example contains a plugin that extendes the dashboard with a mini React app that shows the use of wp-data
-
-
-## Start Guide
-
-The examples in this repo require these three steps to see them in action:
-
-1. Install dependencies
-2. Generate the build
-3. Use it in a WordPress installation
-
-The way to manage the first two steps will be different depending on the context you're using this example.
+The goal of this example is to showcase how to extend the dashboard with a mini React app that shows the use of wp-data
 
 > **Note**
-> At the [WIKI of this repo](https://github.com/WordPress/block-development-examples/wiki) you have the documentation for the examples on this repo
+> Check the [Start Guide for local development with the examples](https://github.com/WordPress/block-development-examples/wiki/02-Examples#start-guide-for-local-development-with-the-examples)
 
+## Understanding the Example Code
 
-### As an example inside this monorepo
-
-The quickest way to have access to all the examples is clone this repository and check out the examples locally.
-
-Check the [05 Development > Repo Commands > Dependencies](https://github.com/WordPress/block-development-examples/wiki/05-Development#dependencies) instructions for this repo to install the dependencies of this example.
-
-Once the depencies are installed (a `node_modules` folder should have been created), [launch the build process](https://github.com/WordPress/block-development-examples/wiki/05-Development#build-process) to get the final version of the block that can be used in WordPress. 
-
-Check the [WordPress Local Development Environment](https://github.com/WordPress/block-development-examples/wiki/05-Development#wordpress-local-development-environment) to learn how to quickly get your local WordPress installation to see this example.
-
-### As an isolated example on your own WordPress installation
-
-If you have a local WordPress installation already running, you can also put the plugin folders of the examples you're interested in (by copying and pasting, from the zips...) inside the `plugins` folder of that installation and check the examples there.
-
-If you do that, you'll need to do the following
-
-- Remove any `node_modules` folder inside this folder
-- Run `npm install` to install the dependencies
-- Run `npm build` to generate the "build" version of the blocks
-- Activate the plugin in your own WordPress installation
-
-At this point you should be able to insert the custom blocks into any post (after activating the plugin) of your WordPress installation, and see how it behaves in the frontend when published.
-
-You can also run `npm start` from this folder to generate a development mode "build" version everytime a change in the code is detected (saved) inside this folder.
-
-
+...write description...

--- a/plugins/plugin-sidebar-9ee4a6/README.md
+++ b/plugins/plugin-sidebar-9ee4a6/README.md
@@ -11,43 +11,9 @@ This example shows how to add a new item to the Top Toolbar in the Block Editor 
 
 ![Screenshot sidebar](assets/screenshot.png)
 
-## Start Guide
-
-The examples in this repo require these three steps to see them in action:
-
-1. Install dependencies
-2. Generate the build
-3. Use it in a WordPress installation
-
-The way to manage the first two steps will be different depending on the context you're using this example.
-
 > **Note**
-> At the [WIKI of this repo](https://github.com/WordPress/block-development-examples/wiki) you have the documentation for the examples on this repo
+> Check the [Start Guide for local development with the examples](https://github.com/WordPress/block-development-examples/wiki/02-Examples#start-guide-for-local-development-with-the-examples)
 
+## Understanding the Example Code
 
-### As an example inside this monorepo
-
-The quickest way to have access to all the examples is clone this repository and check out the examples locally.
-
-Check the [05 Development > Repo Commands > Dependencies](https://github.com/WordPress/block-development-examples/wiki/05-Development#dependencies) instructions for this repo to install the dependencies of this example.
-
-Once the depencies are installed (a `node_modules` folder should have been created), [launch the build process](https://github.com/WordPress/block-development-examples/wiki/05-Development#build-process) to get the final version of the block that can be used in WordPress. 
-
-Check the [WordPress Local Development Environment](https://github.com/WordPress/block-development-examples/wiki/05-Development#wordpress-local-development-environment) to learn how to quickly get your local WordPress installation to see this example.
-
-### As an isolated example on your own WordPress installation
-
-If you have a local WordPress installation already running, you can also put the plugin folders of the examples you're interested in (by copying and pasting, from the zips...) inside the `plugins` folder of that installation and check the examples there.
-
-If you do that, you'll need to do the following
-
-- Remove any `node_modules` folder inside this folder
-- Run `npm install` to install the dependencies
-- Run `npm build` to generate the "build" version of the blocks
-- Activate the plugin in your own WordPress installation
-
-At this point you should be able to insert the custom blocks into any post (after activating the plugin) of your WordPress installation, and see how it behaves in the frontend when published.
-
-You can also run `npm start` from this folder to generate a development mode "build" version everytime a change in the code is detected (saved) inside this folder.
-
-
+...write description...

--- a/plugins/recipe-card-744e8a/README.md
+++ b/plugins/recipe-card-744e8a/README.md
@@ -7,43 +7,11 @@
 | [📁](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/recipe-card-744e8a) | Recipe                                                                    |      | `744e8a`                                                                                                                                     | [📦](https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/recipe-card-744e8a.zip "Install the plugin using this zip and activate it. Then use the ID of the block (744e8a) to find it and add it to a post to see it in action") | [![](https://raw.githubusercontent.com/WordPress/block-development-examples/trunk/assets/icon-wp.svg)](https://playground.wordpress.net/#%7B%22landingPage%22:%22/wp-admin/plugins.php%22,%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22mkdir%22,%22path%22:%22/downloads%22%7D,%7B%22step%22:%22writeFile%22,%22path%22:%22/downloads/plugin.zip%22,%22data%22:%7B%22resource%22:%22url%22,%22url%22:%22https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/recipe-card-744e8a.zip%22,%22caption%22:%22Downloading%20plugin...%22%7D%7D,%7B%22step%22:%22installPlugin%22,%22pluginZipFile%22:%7B%22resource%22:%22vfs%22,%22path%22:%22/downloads/plugin.zip%22%7D%7D%5D%7D "Use the ID of the block (744e8a) to find it and add it to a post to see it in action") |
 <!-- @TABLE EXAMPLES END -->
 
-## Start Guide
-
-The examples in this repo require these three steps to see them in action:
-
-1. Install dependencies
-2. Generate the build
-3. Use it in a WordPress installation
-
-The way to manage the first two steps will be different depending on the context you're using this example.
+The goal of this example is to showcase...
 
 > **Note**
-> At the [WIKI of this repo](https://github.com/WordPress/block-development-examples/wiki) you have the documentation for the examples on this repo
+> Check the [Start Guide for local development with the examples](https://github.com/WordPress/block-development-examples/wiki/02-Examples#start-guide-for-local-development-with-the-examples)
 
+## Understanding the Example Code
 
-### As an example inside this monorepo
-
-The quickest way to have access to all the examples is clone this repository and check out the examples locally.
-
-Check the [05 Development > Repo Commands > Dependencies](https://github.com/WordPress/block-development-examples/wiki/05-Development#dependencies) instructions for this repo to install the dependencies of this example.
-
-Once the depencies are installed (a `node_modules` folder should have been created), [launch the build process](https://github.com/WordPress/block-development-examples/wiki/05-Development#build-process) to get the final version of the block that can be used in WordPress. 
-
-Check the [WordPress Local Development Environment](https://github.com/WordPress/block-development-examples/wiki/05-Development#wordpress-local-development-environment) to learn how to quickly get your local WordPress installation to see this example.
-
-### As an isolated example on your own WordPress installation
-
-If you have a local WordPress installation already running, you can also put the plugin folders of the examples you're interested in (by copying and pasting, from the zips...) inside the `plugins` folder of that installation and check the examples there.
-
-If you do that, you'll need to do the following
-
-- Remove any `node_modules` folder inside this folder
-- Run `npm install` to install the dependencies
-- Run `npm build` to generate the "build" version of the blocks
-- Activate the plugin in your own WordPress installation
-
-At this point you should be able to insert the custom blocks into any post (after activating the plugin) of your WordPress installation, and see how it behaves in the frontend when published.
-
-You can also run `npm start` from this folder to generate a development mode "build" version everytime a change in the code is detected (saved) inside this folder.
-
-
+...write description...

--- a/plugins/slotfill-2fb190/README.md
+++ b/plugins/slotfill-2fb190/README.md
@@ -7,43 +7,11 @@
 | [📁](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/slotfill-2fb190) | SlotFill                                                                  | <small><code><a href="https://github.com/WordPress/block-development-examples/wiki/03-Tags#no-block">NO BLOCK</a></code></small>, <small><code><a href="https://github.com/WordPress/block-development-examples/wiki/03-Tags#slotfill">SLOTFILL</a></code></small> | `2fb190`                                                                                                                                     | [📦](https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/slotfill-2fb190.zip "") | [![](https://raw.githubusercontent.com/WordPress/block-development-examples/trunk/assets/icon-wp.svg)](https://playground.wordpress.net/#%7B%22landingPage%22:%22/wp-admin/plugins.php%22,%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22mkdir%22,%22path%22:%22/downloads%22%7D,%7B%22step%22:%22writeFile%22,%22path%22:%22/downloads/plugin.zip%22,%22data%22:%7B%22resource%22:%22url%22,%22url%22:%22https://raw.githubusercontent.com/WordPress/block-development-examples/deploy/zips/slotfill-2fb190.zip%22,%22caption%22:%22Downloading%20plugin...%22%7D%7D,%7B%22step%22:%22installPlugin%22,%22pluginZipFile%22:%7B%22resource%22:%22vfs%22,%22path%22:%22/downloads/plugin.zip%22%7D%7D%5D%7D "") |
 <!-- @TABLE EXAMPLES END -->
 
-## Start Guide
-
-The examples in this repo require these three steps to see them in action:
-
-1. Install dependencies
-2. Generate the build
-3. Use it in a WordPress installation
-
-The way to manage the first two steps will be different depending on the context you're using this example.
+The goal of this example is to showcase...
 
 > **Note**
-> At the [WIKI of this repo](https://github.com/WordPress/block-development-examples/wiki) you have the documentation for the examples on this repo
+> Check the [Start Guide for local development with the examples](https://github.com/WordPress/block-development-examples/wiki/02-Examples#start-guide-for-local-development-with-the-examples)
 
+## Understanding the Example Code
 
-### As an example inside this monorepo
-
-The quickest way to have access to all the examples is clone this repository and check out the examples locally.
-
-Check the [05 Development > Repo Commands > Dependencies](https://github.com/WordPress/block-development-examples/wiki/05-Development#dependencies) instructions for this repo to install the dependencies of this example.
-
-Once the depencies are installed (a `node_modules` folder should have been created), [launch the build process](https://github.com/WordPress/block-development-examples/wiki/05-Development#build-process) to get the final version of the block that can be used in WordPress. 
-
-Check the [WordPress Local Development Environment](https://github.com/WordPress/block-development-examples/wiki/05-Development#wordpress-local-development-environment) to learn how to quickly get your local WordPress installation to see this example.
-
-### As an isolated example on your own WordPress installation
-
-If you have a local WordPress installation already running, you can also put the plugin folders of the examples you're interested in (by copying and pasting, from the zips...) inside the `plugins` folder of that installation and check the examples there.
-
-If you do that, you'll need to do the following
-
-- Remove any `node_modules` folder inside this folder
-- Run `npm install` to install the dependencies
-- Run `npm build` to generate the "build" version of the blocks
-- Activate the plugin in your own WordPress installation
-
-At this point you should be able to insert the custom blocks into any post (after activating the plugin) of your WordPress installation, and see how it behaves in the frontend when published.
-
-You can also run `npm start` from this folder to generate a development mode "build" version everytime a change in the code is detected (saved) inside this folder.
-
-
+...write description...

--- a/plugins/stylesheets-79a4c3/README.md
+++ b/plugins/stylesheets-79a4c3/README.md
@@ -14,44 +14,9 @@ This example shows how to apply styles to blocks using different sources:
 - styles only for the editor (`editor.scss`)
 - styles shared by the editor and the frontend (`style.scss`)
 
-
-## Start Guide
-
-The examples in this repo require these three steps to see them in action:
-
-1. Install dependencies
-2. Generate the build
-3. Use it in a WordPress installation
-
-The way to manage the first two steps will be different depending on the context you're using this example.
-
 > **Note**
-> At the [WIKI of this repo](https://github.com/WordPress/block-development-examples/wiki) you have the documentation for the examples on this repo
+> Check the [Start Guide for local development with the examples](https://github.com/WordPress/block-development-examples/wiki/02-Examples#start-guide-for-local-development-with-the-examples)
 
+## Understanding the Example Code
 
-### As an example inside this monorepo
-
-The quickest way to have access to all the examples is clone this repository and check out the examples locally.
-
-Check the [05 Development > Repo Commands > Dependencies](https://github.com/WordPress/block-development-examples/wiki/05-Development#dependencies) instructions for this repo to install the dependencies of this example.
-
-Once the depencies are installed (a `node_modules` folder should have been created), [launch the build process](https://github.com/WordPress/block-development-examples/wiki/05-Development#build-process) to get the final version of the block that can be used in WordPress. 
-
-Check the [WordPress Local Development Environment](https://github.com/WordPress/block-development-examples/wiki/05-Development#wordpress-local-development-environment) to learn how to quickly get your local WordPress installation to see this example.
-
-### As an isolated example on your own WordPress installation
-
-If you have a local WordPress installation already running, you can also put the plugin folders of the examples you're interested in (by copying and pasting, from the zips...) inside the `plugins` folder of that installation and check the examples there.
-
-If you do that, you'll need to do the following
-
-- Remove any `node_modules` folder inside this folder
-- Run `npm install` to install the dependencies
-- Run `npm build` to generate the "build" version of the blocks
-- Activate the plugin in your own WordPress installation
-
-At this point you should be able to insert the custom blocks into any post (after activating the plugin) of your WordPress installation, and see how it behaves in the frontend when published.
-
-You can also run `npm start` from this folder to generate a development mode "build" version everytime a change in the code is detected (saved) inside this folder.
-
-
+...write description...

--- a/templates/block-examples/readmes/README-EXAMPLE.tpl.md
+++ b/templates/block-examples/readmes/README-EXAMPLE.tpl.md
@@ -3,43 +3,11 @@
 <!-- @TABLE EXAMPLES BEGIN -->
 <!-- @TABLE EXAMPLES END -->
 
-## Start Guide
-
-The examples in this repo require these three steps to see them in action:
-
-1. Install dependencies
-2. Generate the build
-3. Use it in a WordPress installation
-
-The way to manage the first two steps will be different depending on the context you're using this example.
+The goal of this example is to showcase...
 
 > **Note**
-> At the [WIKI of this repo](https://github.com/WordPress/block-development-examples/wiki) you have the documentation for the examples on this repo
+> Check the [Start Guide for local development with the examples](https://github.com/WordPress/block-development-examples/wiki/02-Examples#start-guide-for-local-development-with-the-examples)
 
+## Understanding the Example Code
 
-### As an example inside this monorepo
-
-The quickest way to have access to all the examples is clone this repository and check out the examples locally.
-
-Check the [05 Development > Repo Commands > Dependencies](https://github.com/WordPress/block-development-examples/wiki/05-Development#dependencies) instructions for this repo to install the dependencies of this example.
-
-Once the depencies are installed (a `node_modules` folder should have been created), [launch the build process](https://github.com/WordPress/block-development-examples/wiki/05-Development#build-process) to get the final version of the block that can be used in WordPress. 
-
-Check the [WordPress Local Development Environment](https://github.com/WordPress/block-development-examples/wiki/05-Development#wordpress-local-development-environment) to learn how to quickly get your local WordPress installation to see this example.
-
-### As an isolated example on your own WordPress installation
-
-If you have a local WordPress installation already running, you can also put the plugin folders of the examples you're interested in (by copying and pasting, from the zips...) inside the `plugins` folder of that installation and check the examples there.
-
-If you do that, you'll need to do the following
-
-- Remove any `node_modules` folder inside this folder
-- Run `npm install` to install the dependencies
-- Run `npm build` to generate the "build" version of the blocks
-- Activate the plugin in your own WordPress installation
-
-At this point you should be able to insert the custom blocks into any post (after activating the plugin) of your WordPress installation, and see how it behaves in the frontend when published.
-
-You can also run `npm start` from this folder to generate a development mode "build" version everytime a change in the code is detected (saved) inside this folder.
-
-
+...write description...


### PR DESCRIPTION
Inspired by https://github.com/wptrainingteam/block-theme-examples the READMEs of each example have been updated to move away the explanations about to work with them locally and put more the focus on the value of each example (see [example](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/basic-block-translations-3df23d))

---

The goal of this example is to showcase...

> **Note**
> Check the [Start Guide for local development with the examples](https://github.com/WordPress/block-development-examples/wiki/02-Examples#start-guide-for-local-development-with-the-examples)

## Understanding the Example Code

...write description...

---