### PR TITLE
Interactivity api countdown getters

### DIFF
--- a/plugins/block-dynamic-rendering-64756b/src/render.php
+++ b/plugins/block-dynamic-rendering-64756b/src/render.php
@@ -8,6 +8,6 @@
  */
 
 ?>
-<p <?php echo get_block_wrapper_attributes(); ?>>
+<p <?php echo get_block_wrapper_attributes(); // phpcs:ignore ?>>
 	<?php esc_html_e( 'Block with Dynamic Rendering – hello!!!', 'block-development-examples' ); ?>
 </p>

--- a/plugins/interactivity-api-countdown-3cd73e/build/block.json
+++ b/plugins/interactivity-api-countdown-3cd73e/build/block.json
@@ -12,7 +12,8 @@
   },
   "attributes": {
     "date": {
-      "type": "string"
+      "type": "string",
+      "default": "2024-01-01T00:00:00"
     }
   },
   "example": {},

--- a/plugins/interactivity-api-countdown-3cd73e/build/render.php
+++ b/plugins/interactivity-api-countdown-3cd73e/build/render.php
@@ -33,8 +33,8 @@ $context = array(
 	data-wp-context='<?php echo wp_json_encode( $context ); ?>' 
 	data-wp-init="callbacks.startCountdown"
 >
-	<span><span data-wp-text="context.days"></span>D</span>
-	<span><span data-wp-text="context.hours"></span>H</span>
-	<span><span data-wp-text="context.minutes"></span>M</span>
-	<span><span data-wp-text="context.seconds"></span>S</span>
+	<span><span data-wp-text="state.days"></span>D</span>
+	<span><span data-wp-text="state.hours"></span>H</span>
+	<span><span data-wp-text="state.minutes"></span>M</span>
+	<span><span data-wp-text="state.seconds"></span>S</span>
 </div>

--- a/plugins/interactivity-api-countdown-3cd73e/src/render.php
+++ b/plugins/interactivity-api-countdown-3cd73e/src/render.php
@@ -33,8 +33,8 @@ $context = array(
 	data-wp-context='<?php echo wp_json_encode( $context ); ?>' 
 	data-wp-init="callbacks.startCountdown"
 >
-	<span><span data-wp-text="context.days"></span>D</span>
-	<span><span data-wp-text="context.hours"></span>H</span>
-	<span><span data-wp-text="context.minutes"></span>M</span>
-	<span><span data-wp-text="context.seconds"></span>S</span>
+	<span><span data-wp-text="state.days"></span>D</span>
+	<span><span data-wp-text="state.hours"></span>H</span>
+	<span><span data-wp-text="state.minutes"></span>M</span>
+	<span><span data-wp-text="state.seconds"></span>S</span>
 </div>

--- a/plugins/interactivity-api-countdown-3cd73e/src/view.js
+++ b/plugins/interactivity-api-countdown-3cd73e/src/view.js
@@ -1,34 +1,36 @@
 import { store, getContext } from '@wordpress/interactivity';
 
 store( 'interactivity-api-countdown-3cd73e__store', {
+	state: {
+		get seconds() {
+			const { remaining } = getContext();
+			return remaining % 60;
+		},
+		get minutes() {
+			const { remaining } = getContext();
+			return Math.floor( remaining / 60 ) % 60;
+		},
+		get hours() {
+			const { remaining } = getContext();
+			return Math.floor( remaining / 3600 ) % 24;
+		},
+		get days() {
+			const { remaining } = getContext();
+			return Math.floor( remaining / 86400 );
+		},
+	},
 	callbacks: {
 		startCountdown: () => {
+			console.log( 'startCountdown...' ); // eslint-disable-line no-console
 			const context = getContext();
-			setInterval( () => {
-				// Calculate seconds.
-				if ( context.seconds - 1 < 0 ) {
-					context.seconds = context.minutes > 0 ? 59 : 0;
-					// Calculate minutes.
-					if ( context.minutes - 1 < 0 ) {
-						context.minutes = context.hours > 0 ? 59 : 0;
-						// Calculate hours.
-						if ( context.hours - 1 < 0 ) {
-							context.hours = context.days > 0 ? 23 : 0;
-							// Calculate days.
-							if ( context.days - 1 < 0 ) {
-								context.days = 0;
-							} else {
-								context.days--;
-							}
-						} else {
-							context.hours--;
-						}
-					} else {
-						context.minutes--;
-					}
-				} else {
-					context.seconds--;
-				}
+			const { days, hours, minutes, seconds } = context;
+			context.remaining =
+				days * 86400 + hours * 3600 + minutes * 60 + seconds;
+			// Update remaining time (in seconds).
+			const n = setInterval( () => {
+				context.remaining -= 1;
+				if ( context.remaining === 0 ) clearInterval( n );
+				console.log( context.remaining ); // eslint-disable-line no-console
 			}, 1000 );
 		},
 	},

--- a/plugins/interactivity-api-countdown-3cd73e/src/view.js
+++ b/plugins/interactivity-api-countdown-3cd73e/src/view.js
@@ -30,7 +30,6 @@ store( 'interactivity-api-countdown-3cd73e__store', {
 			const n = setInterval( () => {
 				context.remaining -= 1;
 				if ( context.remaining === 0 ) clearInterval( n );
-				console.log( context.remaining ); // eslint-disable-line no-console
 			}, 1000 );
 		},
 	},


### PR DESCRIPTION
As per @DAreRodz suggestion I open this PR with this new version of `view.js` 
The current code still doesn't work. It logs the `remaining` value but frontend values (days, hours...) are not updated.

This example can be checked with the following steps:
- Go to `interactivity-api-countdown-3cd73e` folder
- Run `npx @wp-now/wp-now start --wp=6.4 --reset`
- Install and activate Gutenberg 17.2 or superior
- Insert the "Countdown 3cd73e" block in a post and see post published 
