### PR TITLE
Enforce requirement: Must have Gutenberg plugin installed

### DIFF
--- a/plugins/interactivity-api-countdown-3cd73e/interactivity-api-countdown-3cd73e.php
+++ b/plugins/interactivity-api-countdown-3cd73e/interactivity-api-countdown-3cd73e.php
@@ -4,6 +4,7 @@
  * Description:       Countdown created with the Interactivity API
  * Requires at least: 6.1
  * Requires PHP:      7.0
+ * Requires Plugins:  gutenberg
  * Version:           0.1.0
  * Author:            The WordPress Contributors
  * License:           GPL-2.0-or-later


### PR DESCRIPTION
As of WordPress 6.5, plugins can throw an error if another plugin they depend on is not installed.

In the case of the Interactivity API - as of now - Gutenberg is required. This PR makes the user aware of this requirement, and prompts them to install the plugin if it is not installed when trying to use the block.

Proof of concept/testing the [new header](https://make.wordpress.org/core/2024/03/05/introducing-plugin-dependencies-in-wordpress-6-5/#:~:text=New%20Plugin%20Header,php%20is%20not%20supported)