### PR TITLE
Fix breaking error when the meta field does not exist

### DIFF
--- a/plugins/plugin-sidebar-9ee4a6/src/plugin-sidebar-9ee4a6.js
+++ b/plugins/plugin-sidebar-9ee4a6/src/plugin-sidebar-9ee4a6.js
@@ -12,7 +12,7 @@ const MetaBlockField = () => {
 		<PanelBody>
 			<TextControl
 				label="Meta Block Field"
-				value={ meta?.sidebar_plugin_meta_block_field || "" }
+				value={ meta?.sidebar_plugin_meta_block_field || '' }
 				onChange={ ( newValue ) =>
 					setMeta( {
 						...meta,

--- a/plugins/plugin-sidebar-9ee4a6/src/plugin-sidebar-9ee4a6.js
+++ b/plugins/plugin-sidebar-9ee4a6/src/plugin-sidebar-9ee4a6.js
@@ -12,7 +12,7 @@ const MetaBlockField = () => {
 		<PanelBody>
 			<TextControl
 				label="Meta Block Field"
-				value={ meta.sidebar_plugin_meta_block_field }
+				value={ meta?.sidebar_plugin_meta_block_field || "" }
 				onChange={ ( newValue ) =>
 					setMeta( {
 						...meta,


### PR DESCRIPTION
If the meta field `sidebar_plugin_meta_block_field` does not exist for the page/post, you will get a console error, and the Editor will crash. This modification fixes that.