### PR TITLE
WP version bump for Interactivity API - must have at least 6.5

### DIFF
--- a/plugins/interactivity-api-countdown-3cd73e/interactivity-api-countdown-3cd73e.php
+++ b/plugins/interactivity-api-countdown-3cd73e/interactivity-api-countdown-3cd73e.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Block Development Examples - Countdown 3cd73e
  * Description:       Countdown created with the Interactivity API
- * Requires at least: 6.1
+ * Requires at least: 6.5
  * Requires PHP:      7.0
  * Version:           0.1.0
  * Author:            The WordPress Contributors


### PR DESCRIPTION
Change minimum version to 6.5 for Interactivity API to work with countdown block