### PR TITLE
Add/rich text no build example

### DIFF
--- a/plugins/editable-block-1b8c51/_playground/export.xml
+++ b/plugins/editable-block-1b8c51/_playground/export.xml
@@ -61,7 +61,15 @@
 
 <!-- wp:block-development-examples/enhanced-editable-block-1b8c51 -->
 <p class="wp-block-block-development-examples-enhanced-editable-block-1b8c51">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the </p>
-<!-- /wp:block-development-examples/enhanced-editable-block-1b8c51 -->]]></content:encoded>
+<!-- /wp:block-development-examples/enhanced-editable-block-1b8c51 -->
+
+<!-- wp:paragraph -->
+<p><strong>Basic Editable Block (no build)</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:block-development-examples/basic-editable-block-no-build-1b8c51 -->
+<p class="wp-block-block-development-examples-basic-editable-block-no-build-1b8c51">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the </p>
+<!-- /wp:block-development-examples/basic-editable-block-no-build-1b8c51 -->]]></content:encoded>
 		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
 		<wp:post_id>10</wp:post_id>
 		<wp:post_date><![CDATA[2024-05-16 06:56:41]]></wp:post_date>

--- a/plugins/editable-block-1b8c51/package.json
+++ b/plugins/editable-block-1b8c51/package.json
@@ -6,7 +6,7 @@
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"scripts": {
-		"build": "wp-scripts build",
+		"build": "wp-scripts build && npm run copy:non-build",
 		"check-engines": "wp-scripts check-engines",
 		"check-licenses": "wp-scripts check-licenses",
 		"format": "wp-scripts format",
@@ -18,10 +18,12 @@
 		"plugin-zip": "wp-scripts plugin-zip",
 		"start": "wp-scripts start",
 		"test:e2e": "wp-scripts test-e2e",
-		"test:unit": "wp-scripts test-unit-js"
+		"test:unit": "wp-scripts test-unit-js",
+		"copy:non-build": "shx cp -r src/blocks/*no-build*/ build/blocks/"
 	},
 	"devDependencies": {
-		"@wordpress/scripts": "^27.8.0"
+		"@wordpress/scripts": "^27.8.0",
+		"shx": "^0.3.4"
 	},
 	"files": [
 		"*"

--- a/plugins/editable-block-1b8c51/src/blocks/basic-editable-block-no-build-1b8c51/block.asset.php
+++ b/plugins/editable-block-1b8c51/src/blocks/basic-editable-block-no-build-1b8c51/block.asset.php
@@ -1,0 +1,4 @@
+<?php return [
+    "dependencies" => ["react", "wp-block-editor", "wp-blocks"],
+    "version" => "jns4hjf256k63try7oq4",
+];

--- a/plugins/editable-block-1b8c51/src/blocks/basic-editable-block-no-build-1b8c51/block.js
+++ b/plugins/editable-block-1b8c51/src/blocks/basic-editable-block-no-build-1b8c51/block.js
@@ -1,0 +1,53 @@
+( function ( blocks, blockEditor, element ) {
+	const el = element.createElement;
+	const { useBlockProps, RichText } = blockEditor;
+
+	const Edit = ( props ) => {
+		const {
+			attributes: { content },
+			setAttributes,
+		} = props;
+
+		const blockProps = useBlockProps();
+
+		const onChangeContent = ( newContent ) => {
+			setAttributes( { content: newContent } );
+		};
+
+		return el(
+			RichText,
+			{
+				...blockProps,
+				tagName: 'p',
+				onChange: onChangeContent,
+				value: content,
+			},
+			''
+		);
+	};
+
+	const save = ( props ) => {
+		const {
+			attributes: { content },
+		} = props;
+		const blockProps = useBlockProps.save();
+
+		return el(
+			RichText.Content,
+			{
+				...blockProps,
+				tagName: 'p',
+				value: content,
+			},
+			''
+		);
+	};
+
+	blocks.registerBlockType(
+		'block-development-examples/basic-editable-block-no-build-1b8c51',
+		{
+			edit: Edit,
+			save,
+		}
+	);
+} )( window.wp.blocks, window.wp.blockEditor, window.wp.element );

--- a/plugins/editable-block-1b8c51/src/blocks/basic-editable-block-no-build-1b8c51/block.json
+++ b/plugins/editable-block-1b8c51/src/blocks/basic-editable-block-no-build-1b8c51/block.json
@@ -1,0 +1,23 @@
+{
+	"apiVersion": 3,
+	"title": "Editable Block No Build",
+	"name": "block-development-examples/basic-editable-block-no-build-1b8c51",
+	"category": "media",
+	"icon": "universal-access-alt",
+	"keywords": [ "1b8c51" ],
+	"attributes": {
+		"content": {
+			"type": "string",
+			"source": "html",
+			"selector": "p"
+		}
+	},
+	"example": {
+		"attributes": {
+			"content": "Hello world"
+		}
+	},
+	"editorScript": "file:./block.js",
+	"editorStyle": "file:./editor.css",
+	"style": "file:./style.css"
+}

--- a/plugins/editable-block-1b8c51/src/blocks/basic-editable-block-no-build-1b8c51/editor.css
+++ b/plugins/editable-block-1b8c51/src/blocks/basic-editable-block-no-build-1b8c51/editor.css
@@ -1,0 +1,10 @@
+/**
+ * Note that these styles are loaded *after* common styles, so that
+ * editor-specific styles using the same selectors will take precedence.
+ */
+.wp-block-block-development-examples-basic-editable-block-1b8c51 {
+	color: #008000;
+	background: #cfc;
+	border: 2px solid #9c9;
+	padding: 20px;
+}

--- a/plugins/editable-block-1b8c51/src/blocks/basic-editable-block-no-build-1b8c51/editor.css
+++ b/plugins/editable-block-1b8c51/src/blocks/basic-editable-block-no-build-1b8c51/editor.css
@@ -2,7 +2,7 @@
  * Note that these styles are loaded *after* common styles, so that
  * editor-specific styles using the same selectors will take precedence.
  */
-.wp-block-block-development-examples-basic-editable-block-1b8c51 {
+.wp-block-block-development-examples-basic-editable-block-no-build-1b8c51 {
 	color: #008000;
 	background: #cfc;
 	border: 2px solid #9c9;

--- a/plugins/editable-block-1b8c51/src/blocks/basic-editable-block-no-build-1b8c51/style.css
+++ b/plugins/editable-block-1b8c51/src/blocks/basic-editable-block-no-build-1b8c51/style.css
@@ -1,0 +1,10 @@
+/**
+ * Note that these styles are loaded *before* editor styles, so that
+ * editor-specific styles using the same selectors will take precedence.
+ */
+.wp-block-block-development-examples-basic-editable-block-1b8c51 {
+	color: #00198b;
+	background: rgb(204, 248, 255);
+	border: 2px solid #c99;
+	padding: 20px;
+}

--- a/plugins/editable-block-1b8c51/src/blocks/basic-editable-block-no-build-1b8c51/style.css
+++ b/plugins/editable-block-1b8c51/src/blocks/basic-editable-block-no-build-1b8c51/style.css
@@ -2,7 +2,7 @@
  * Note that these styles are loaded *before* editor styles, so that
  * editor-specific styles using the same selectors will take precedence.
  */
-.wp-block-block-development-examples-basic-editable-block-1b8c51 {
+.wp-block-block-development-examples-basic-editable-block-no-build-1b8c51 {
 	color: #00198b;
 	background: rgb(204, 248, 255);
 	border: 2px solid #c99;

--- a/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-1835fa/style.css
+++ b/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-1835fa/style.css
@@ -1,4 +1,4 @@
 .wp-block-block-development-examples-quiz-1835fa .active {
-	border: 2px solid green;
-	background-color: limegreen;
+	border: 2px solid #006400;
+	background-color: #90ee90;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       '@wordpress/scripts':
         specifier: ^27.8.0
         version: 27.8.0(@playwright/test@1.44.0)(react-dom@18.3.1)(react@18.3.1)(typescript@5.4.5)
+      shx:
+        specifier: ^0.3.4
+        version: 0.3.4
 
   plugins/format-api-f14b86:
     devDependencies:
@@ -7655,6 +7658,7 @@ packages:
 
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -8145,6 +8149,7 @@ packages:
 
   /inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
@@ -8190,6 +8195,11 @@ packages:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.0.6
+    dev: true
+
+  /interpret@1.4.0:
+    resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
+    engines: {node: '>= 0.10'}
     dev: true
 
   /interpret@3.1.1:
@@ -11310,6 +11320,13 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /rechoir@0.6.2:
+    resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      resolve: 1.22.8
+    dev: true
+
   /rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
     engines: {node: '>= 10.13.0'}
@@ -11879,12 +11896,31 @@ packages:
     resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
     dev: true
 
+  /shelljs@0.8.5:
+    resolution: {integrity: sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==}
+    engines: {node: '>=4'}
+    hasBin: true
+    dependencies:
+      glob: 7.2.3
+      interpret: 1.4.0
+      rechoir: 0.6.2
+    dev: true
+
   /showdown@1.9.1:
     resolution: {integrity: sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==}
     hasBin: true
     dependencies:
       yargs: 14.2.3
     dev: false
+
+  /shx@0.3.4:
+    resolution: {integrity: sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==}
+    engines: {node: '>=6'}
+    hasBin: true
+    dependencies:
+      minimist: 1.2.8
+      shelljs: 0.8.5
+    dev: true
 
   /side-channel@1.0.6:
     resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}


### PR DESCRIPTION
This PR adds an example of using the RichText component in a no-build workflow.
As requested at https://github.com/WordPress/block-development-examples/issues/113