### PR TITLE
Update WCEU workshop interactivity example with WP 6.5 syntax

### DIFF
--- a/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-1835fa/render.php
+++ b/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-1835fa/render.php
@@ -42,7 +42,7 @@ $context = array(
 	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
 	data-wp-interactive="quiz-1835fa-project-store"
 	data-wp-on--keydown="actions.closeOnEsc"
-	<?php echo wp_interactivity_data_wp_context( $context ); ?>
+	<?php echo wp_kses_data( wp_interactivity_data_wp_context( $context ) ); ?>
 >
 	<div>
 		<strong>
@@ -54,6 +54,7 @@ $context = array(
 			data-wp-bind--aria-expanded="state.isOpen"
 			aria-controls="<?php echo esc_attr( $unique_id ); ?>"
 			data-wp-text="state.toggleText"
+			data-wp-bind--disabled="state.showAnswers"
 		></button>
 	</div>
 

--- a/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-1835fa/render.php
+++ b/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-1835fa/render.php
@@ -11,35 +11,38 @@
  * @package BlockDevelopmentExamples\Quiz1835fa
  */
 
-$unique_id = substr( uniqid(), -5 );
+$unique_id = wp_unique_id( 'quiz-' );
 
 wp_interactivity_state(
 	'quiz-1835fa-project-store',
 	array(
-		'quizSelected' => null,
-		'openText'     => __( 'Open menu' ),
-		'closeText'    => __( 'Close menu' ),
-		'quizzes'      => array(
+		'openText'    => __( 'Open' ),
+		'closeText'   => __( 'Close' ),
+		'selected'    => null,
+		'isOpen'      => false,
+		'toggleText'  => __( 'Open' ),
+		'isActive'    => false,
+		'inputAnswer' => '',
+		'quizzes'     => array(
 			$unique_id => array(
 				'current' => null,
 				'correct' => $attributes['answer'],
 			),
 		),
-		'toggleText'   => __( 'Open menu' ),
-		'isActive'     => false,
-		'inputAnswer'  => null,
 	)
 );
 
-
+$context = array(
+	'id'     => $unique_id,
+	'answer' => null,
+);
 ?>
 
 <div
 	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
-	data-wp-interactive='{"namespace": "quiz-1835fa-project-store"}'
-	data-wp-context='{ "id": "<?php echo esc_attr( $unique_id ); ?>" , "answer": null }'
+	data-wp-interactive="quiz-1835fa-project-store"
 	data-wp-on--keydown="actions.closeOnEsc"
-	data-wp-watch="callbacks.log"
+	<?php echo wp_interactivity_data_wp_context( $context ); ?>
 >
 	<div>
 		<strong>
@@ -49,15 +52,14 @@ wp_interactivity_state(
 		<button
 			data-wp-on--click="actions.toggle"
 			data-wp-bind--aria-expanded="state.isOpen"
+			aria-controls="<?php echo esc_attr( $unique_id ); ?>"
 			data-wp-text="state.toggleText"
-			aria-controls="quiz-<?php echo esc_attr( $unique_id ); ?>"
-		>
-		</button>
+		></button>
 	</div>
 
 	<div
 		data-wp-bind--hidden="!state.isOpen"
-		id="quiz-<?php echo esc_attr( $unique_id ); ?>"
+		id="<?php echo esc_attr( $unique_id ); ?>"
 	>
 		<?php if ( 'boolean' === $attributes['typeOfQuiz'] ) : ?>
 			<button

--- a/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-1835fa/view.js
+++ b/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-1835fa/view.js
@@ -1,64 +1,40 @@
 /**
  * WordPress dependencies
  */
-import { store, getContext, getElement } from "@wordpress/interactivity";
+import { store } from '@wordpress/interactivity';
 
-const { state } = store("quiz-1835fa-project-store", {
-  state: {
-    get isOpen() {
-      const { id } = getContext();
-      return state.selected === id;
-    },
-    get toggleText() {
-      return state.isOpen ? state.closeText : state.openText;
-    },
-    get isActive() {
-      const { id, thisAnswer } = getContext();
-      return state.quizzes[id].current === thisAnswer;
-    },
-    get inputAnswer() {
-      const { id } = getContext();
-      return state.quizzes[id].current || "";
-    },
-  },
-  actions: {
-    toggle() {
-      const { id } = getContext();
-
-      if (state.selected === id) {
-        state.selected = null;
-      } else {
-        state.selected = id;
-      }
-    },
-    closeOnEsc(event) {
-      if (event.key === "Escape") {
-        state.selected = null;
-        const { ref } = getElement();
-        ref.querySelector('button[aria-controls^="quiz-"]').focus();
-      }
-    },
-    answerBoolean() {
-      const { id, thisAnswer } = getContext();
-      const quiz = state.quizzes[id];
-
-      if (quiz.current !== thisAnswer) {
-        quiz.current = thisAnswer;
-      } else {
-        quiz.current = null;
-      }
-    },
-    answerInput(event) {
-      const { id } = getContext();
-      state.quizzes[id].current = event.target.value || null;
-    },
-  },
-  callbacks: {
-    focusOnOpen() {
-      if (state.isOpen) {
-        const { ref } = getElement();
-        ref.focus();
-      }
-    },
-  },
-});
+const { state } = store( 'quiz-1835fa-project-store', {
+	state: {
+		get answered() {
+			return Object.values( state.quizzes ).filter(
+				( v ) => v.current !== null
+			).length;
+		},
+		get allAnswered() {
+			return state.answered === Object.keys( state.quizzes ).length;
+		},
+		get correct() {
+			return state.showAnswers
+				? Object.values( state.quizzes ).filter(
+						( v ) => v.current === v.correct
+				  ).length
+				: '?';
+		},
+		get allCorrect() {
+			return state.correct === Object.keys( state.quizzes ).length;
+		},
+	},
+	actions: {
+		checkAnswers: () => {
+			state.showAnswers = true;
+			state.selected = null;
+		},
+		reset: () => {
+			state.showAnswers = false;
+			state.selected = null;
+			Object.values( state.quizzes ).forEach( ( quiz ) => {
+				quiz.current = null;
+			} );
+		},
+	},
+} );

--- a/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-1835fa/view.js
+++ b/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-1835fa/view.js
@@ -1,55 +1,64 @@
-import { store, getContext, getElement } from '@wordpress/interactivity';
+/**
+ * WordPress dependencies
+ */
+import { store, getContext, getElement } from "@wordpress/interactivity";
 
-const { state } = store( 'quiz-1835fa-project-store', {
-	state: {
-		get isOpen() {
-			const { id: quizId } = getContext();
-			return state.selected === quizId;
-		},
-		get toggleText() {
-			return state.isOpen ? state.closeText : state.openText;
-		},
-		get isActive() {
-			const { id: quizId, thisAnswer } = getContext();
-			return state.quizzes[ quizId ].current === thisAnswer;
-		},
-		get inputAnswer() {
-			const { id: quizId } = getContext();
-			return state.quizzes[ quizId ].current || '';
-		},
-	},
-	actions: {
-		toggle: () => {
-			const { id: quizId } = getContext();
-			if ( state.selected === quizId ) {
-				state.selected = null;
-			} else {
-				state.selected = quizId;
-			}
-		},
-		closeOnEsc: ( event ) => {
-			const { ref } = getElement();
-			if ( event.key === 'Escape' ) {
-				state.selected = null;
-				ref.querySelector( 'button[aria-controls^="quiz-"]' ).focus();
-			}
-		},
-		answerBoolean: () => {
-			const { id: quizId, thisAnswer } = getContext();
-			const quiz = state.quizzes[ quizId ];
-			quiz.current = quiz.current !== thisAnswer ? thisAnswer : null;
-		},
-		answerInput: ( event ) => {
-			const { id: quizId } = getContext();
-			state.quizzes[ quizId ].current = event.target.value || null;
-		},
-	},
-	callbacks: {
-		focusOnOpen: () => {
-			const { ref } = getElement();
-			if ( state.isOpen ) {
-				ref.focus();
-			}
-		},
-	},
-} );
+const { state } = store("quiz-1835fa-project-store", {
+  state: {
+    get isOpen() {
+      const { id } = getContext();
+      return state.selected === id;
+    },
+    get toggleText() {
+      return state.isOpen ? state.closeText : state.openText;
+    },
+    get isActive() {
+      const { id, thisAnswer } = getContext();
+      return state.quizzes[id].current === thisAnswer;
+    },
+    get inputAnswer() {
+      const { id } = getContext();
+      return state.quizzes[id].current || "";
+    },
+  },
+  actions: {
+    toggle() {
+      const { id } = getContext();
+
+      if (state.selected === id) {
+        state.selected = null;
+      } else {
+        state.selected = id;
+      }
+    },
+    closeOnEsc(event) {
+      if (event.key === "Escape") {
+        state.selected = null;
+        const { ref } = getElement();
+        ref.querySelector('button[aria-controls^="quiz-"]').focus();
+      }
+    },
+    answerBoolean() {
+      const { id, thisAnswer } = getContext();
+      const quiz = state.quizzes[id];
+
+      if (quiz.current !== thisAnswer) {
+        quiz.current = thisAnswer;
+      } else {
+        quiz.current = null;
+      }
+    },
+    answerInput(event) {
+      const { id } = getContext();
+      state.quizzes[id].current = event.target.value || null;
+    },
+  },
+  callbacks: {
+    focusOnOpen() {
+      if (state.isOpen) {
+        const { ref } = getElement();
+        ref.focus();
+      }
+    },
+  },
+});

--- a/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-progress-1835fa/render.php
+++ b/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-progress-1835fa/render.php
@@ -11,7 +11,7 @@
  * @package BlockDevelopmentExamples\QuizProgress1835fa
  */
 
-wp_interactivity_state(
+$state = wp_interactivity_state(
 	'quiz-1835fa-project-store',
 	array(
 		'showAnswers' => false,
@@ -26,11 +26,11 @@ wp_interactivity_state(
 
 <div
 	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
-	data-wp-interactive='{"namespace": "quiz-1835fa-project-store"}'
+	data-wp-interactive="quiz-1835fa-project-store"
 >
 	<div>
 		<strong><?php echo wp_kses_data( __( 'Answered' ) ); ?></strong>: 
-		<span data-wp-text="state.answered"></span> / <span data-wp-text="state.totalQuizzes"></span>
+		<span data-wp-text="state.answered"></span>/<?php echo count( $state['quizzes'] ); ?>
 	</div>
 
 	<div>
@@ -40,7 +40,6 @@ wp_interactivity_state(
 			<?php echo wp_kses_data( __( 'All correct, congratulations!' ) ); ?>
 		</span>
 	</div>
-
 	<div>
 		<button
 			data-wp-bind--hidden="state.showAnswers"

--- a/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-progress-1835fa/render.php
+++ b/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-progress-1835fa/render.php
@@ -36,9 +36,9 @@ $state = wp_interactivity_state(
 	<div>
 		<strong><?php echo wp_kses_data( __( 'Correct' ) ); ?></strong>: 
 		<span data-wp-text="state.correct"></span>
-		<span data-wp-bind--hidden="!state.allCorrect">
-			<?php echo wp_kses_data( __( 'All correct, congratulations!' ) ); ?>
-		</span>
+		<div data-wp-bind--hidden="!state.allCorrect">
+			<?php echo wp_kses_data( __( 'All correct, congratulations! 🎉' ) ); ?>
+		</div>
 	</div>
 	<div>
 		<button

--- a/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-progress-1835fa/render.php
+++ b/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-progress-1835fa/render.php
@@ -59,6 +59,10 @@ $state = wp_interactivity_state(
 	<hr>
 
 	<div>
-		<?php echo wp_kses_data( $content ); ?>
+		
+		<?php
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $content;
+		?>
 	</div>
 </div>

--- a/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-progress-1835fa/view.js
+++ b/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-progress-1835fa/view.js
@@ -1,64 +1,64 @@
 /**
  * WordPress dependencies
  */
-import { store, getContext, getElement } from "@wordpress/interactivity";
+import { store, getContext, getElement } from '@wordpress/interactivity';
 
-const { state } = store("quiz-1835fa-project-store", {
-  state: {
-    get isOpen() {
-      const { id } = getContext();
-      return state.selected === id;
-    },
-    get toggleText() {
-      return state.isOpen ? state.closeText : state.openText;
-    },
-    get isActive() {
-      const { id, thisAnswer } = getContext();
-      return state.quizzes[id].current === thisAnswer;
-    },
-    get inputAnswer() {
-      const { id } = getContext();
-      return state.quizzes[id].current || "";
-    },
-  },
-  actions: {
-    toggle() {
-      const { id } = getContext();
+const { state } = store( 'quiz-1835fa-project-store', {
+	state: {
+		get isOpen() {
+			const { id } = getContext();
+			return state.selected === id;
+		},
+		get toggleText() {
+			return state.isOpen ? state.closeText : state.openText;
+		},
+		get isActive() {
+			const { id, thisAnswer } = getContext();
+			return state.quizzes[ id ].current === thisAnswer;
+		},
+		get inputAnswer() {
+			const { id } = getContext();
+			return state.quizzes[ id ].current || '';
+		},
+	},
+	actions: {
+		toggle() {
+			const { id } = getContext();
 
-      if (state.selected === id) {
-        state.selected = null;
-      } else {
-        state.selected = id;
-      }
-    },
-    closeOnEsc(event) {
-      if (event.key === "Escape") {
-        state.selected = null;
-        const { ref } = getElement();
-        ref.querySelector('button[aria-controls^="quiz-"]').focus();
-      }
-    },
-    answerBoolean() {
-      const { id, thisAnswer } = getContext();
-      const quiz = state.quizzes[id];
+			if ( state.selected === id ) {
+				state.selected = null;
+			} else {
+				state.selected = id;
+			}
+		},
+		closeOnEsc( event ) {
+			if ( event.key === 'Escape' ) {
+				state.selected = null;
+				const { ref } = getElement();
+				ref.querySelector( 'button[aria-controls^="quiz-"]' ).focus();
+			}
+		},
+		answerBoolean() {
+			const { id, thisAnswer } = getContext();
+			const quiz = state.quizzes[ id ];
 
-      if (quiz.current !== thisAnswer) {
-        quiz.current = thisAnswer;
-      } else {
-        quiz.current = null;
-      }
-    },
-    answerInput(event) {
-      const { id } = getContext();
-      state.quizzes[id].current = event.target.value || null;
-    },
-  },
-  callbacks: {
-    focusOnOpen() {
-      if (state.isOpen) {
-        const { ref } = getElement();
-        ref.focus();
-      }
-    },
-  },
-});
+			if ( quiz.current !== thisAnswer ) {
+				quiz.current = thisAnswer;
+			} else {
+				quiz.current = null;
+			}
+		},
+		answerInput( event ) {
+			const { id } = getContext();
+			state.quizzes[ id ].current = event.target.value || null;
+		},
+	},
+	callbacks: {
+		focusOnOpen() {
+			if ( state.isOpen ) {
+				const { ref } = getElement();
+				ref.focus();
+			}
+		},
+	},
+} );

--- a/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-progress-1835fa/view.js
+++ b/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-progress-1835fa/view.js
@@ -1,39 +1,64 @@
-import { store } from '@wordpress/interactivity';
+/**
+ * WordPress dependencies
+ */
+import { store, getContext, getElement } from "@wordpress/interactivity";
 
-const { state } = store( 'quiz-1835fa-project-store', {
-	state: {
-		get answered() {
-			return Object.values( state.quizzes ).filter(
-				( v ) => v.current !== null
-			).length;
-		},
-		get allAnswered() {
-			return state.answered === Object.keys( state.quizzes ).length;
-		},
-		get correct() {
-			return state.showAnswers
-				? Object.values( state.quizzes ).filter(
-						( v ) => v.current === v.correct
-				  ).length
-				: '?';
-		},
-		get allCorrect() {
-			return state.correct === Object.keys( state.quizzes ).length;
-		},
-		get totalQuizzes() {
-			return Object.values( state.quizzes ).length;
-		},
-	},
-	actions: {
-		checkAnswers: () => {
-			state.showAnswers = true;
-			state.selected = null;
-		},
-		reset: () => {
-			state.showAnswers = false;
-			Object.values( state.quizzes ).forEach( ( quiz ) => {
-				quiz.current = null;
-			} );
-		},
-	},
-} );
+const { state } = store("quiz-1835fa-project-store", {
+  state: {
+    get isOpen() {
+      const { id } = getContext();
+      return state.selected === id;
+    },
+    get toggleText() {
+      return state.isOpen ? state.closeText : state.openText;
+    },
+    get isActive() {
+      const { id, thisAnswer } = getContext();
+      return state.quizzes[id].current === thisAnswer;
+    },
+    get inputAnswer() {
+      const { id } = getContext();
+      return state.quizzes[id].current || "";
+    },
+  },
+  actions: {
+    toggle() {
+      const { id } = getContext();
+
+      if (state.selected === id) {
+        state.selected = null;
+      } else {
+        state.selected = id;
+      }
+    },
+    closeOnEsc(event) {
+      if (event.key === "Escape") {
+        state.selected = null;
+        const { ref } = getElement();
+        ref.querySelector('button[aria-controls^="quiz-"]').focus();
+      }
+    },
+    answerBoolean() {
+      const { id, thisAnswer } = getContext();
+      const quiz = state.quizzes[id];
+
+      if (quiz.current !== thisAnswer) {
+        quiz.current = thisAnswer;
+      } else {
+        quiz.current = null;
+      }
+    },
+    answerInput(event) {
+      const { id } = getContext();
+      state.quizzes[id].current = event.target.value || null;
+    },
+  },
+  callbacks: {
+    focusOnOpen() {
+      if (state.isOpen) {
+        const { ref } = getElement();
+        ref.focus();
+      }
+    },
+  },
+});


### PR DESCRIPTION
@verytwisty helped [me update the syntax of the WCEU workshop blocks](https://github.com/luisherranz/wceu2023/pull/1) to the final version of the Interactivity API included in WP 6.5.

This pull request brings that update to the example shared in this repository.

@juanmaguitar I haven't tested this locally, but I believe there's a way to test this using the Playground with a link generated directly in this repository. Is that the case?