### PR TITLE
Fix number of quizzes in the Interactivity API example

### DIFF
--- a/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-progress-1835fa/render.php
+++ b/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-progress-1835fa/render.php
@@ -22,6 +22,8 @@ $state = wp_interactivity_state(
 	)
 );
 
+$number_of_quizzes = isset( $state['quizzes'] ) ? count( $state['quizzes'] ) : 0;
+
 ?>
 
 <div
@@ -30,7 +32,7 @@ $state = wp_interactivity_state(
 >
 	<div>
 		<strong><?php echo wp_kses_data( __( 'Answered' ) ); ?></strong>: 
-		<span data-wp-text="state.answered"></span> / <span data-wp-text="state.totalQuizzes"></span>
+		<span data-wp-text="state.answered"></span> / <?php echo wp_kses_data( $number_of_quizzes ); ?>
 	</div>
 
 	<div>

--- a/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-progress-1835fa/view.js
+++ b/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-progress-1835fa/view.js
@@ -20,9 +20,6 @@ const { state } = store( 'quiz-1835fa-project-store', {
 			const { id } = getContext();
 			return state.quizzes[ id ].current || '';
 		},
-		get totalQuizzes() {
-			return state.quizzes?.length || 0;
-		},
 	},
 	actions: {
 		toggle() {


### PR DESCRIPTION
I fixed the server error that occurred when reading the number of quizzes on the page.

Additionally, we need to change the blueprint so that the quizzes are inner blocks of the Quiz Progress block.