### PR TITLE
Make it so quiz blocks can only be added as inner blocks of quizz progress

### DIFF
--- a/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-1835fa/block.json
+++ b/plugins/interactivity-api-quiz-1835fa/src/blocks/quiz-1835fa/block.json
@@ -11,6 +11,7 @@
 	"supports": {
 		"interactivity": true
 	},
+	"parent": [ "block-development-examples/quiz-progress-1835fa" ],
 	"attributes": {
 		"question": {
 			"type": "string"


### PR DESCRIPTION
Sorry, another pull request to improve the Interactivity API quizz examples 😄