### PR TITLE
    plugins/data-basics-59c8f8: remove redundant package and code

### DIFF
--- a/plugins/data-basics-59c8f8/src/components/DeletePageButton.js
+++ b/plugins/data-basics-59c8f8/src/components/DeletePageButton.js
@@ -34,7 +34,7 @@ const DeletePageButton = ( { pageId } ) => {
 		}
 	};
 	const { deleteEntityRecord } = useDispatch( coreDataStore );
-	const { isDeleting, error } = useSelect(
+	const { isDeleting } = useSelect(
 		( select ) => ( {
 			isDeleting: select( coreDataStore ).isDeletingEntityRecord(
 				'postType',

--- a/plugins/data-basics-59c8f8/src/components/DeletePageButton.js
+++ b/plugins/data-basics-59c8f8/src/components/DeletePageButton.js
@@ -1,7 +1,6 @@
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
 import { Button, Spinner } from '@wordpress/components';
 
 const DeletePageButton = ( { pageId } ) => {
@@ -42,19 +41,8 @@ const DeletePageButton = ( { pageId } ) => {
 				'page',
 				pageId
 			),
-			error: select( coreDataStore ).getLastEntityDeleteError(
-				'postType',
-				'page',
-				pageId
-			),
-		} ),
-		[ pageId ]
+		} )
 	);
-	useEffect( () => {
-		if ( error ) {
-			// Display the error
-		}
-	}, [ error ] );
 	return (
 		<Button
 			variant="primary"


### PR DESCRIPTION
We use Snackbar for Delete Notifications so useEffect package and related code are redundant.
The last paramId is also redundant.