### PR TITLE
Update Interactivity API tag description

### DIFF
--- a/_data/tags.json
+++ b/_data/tags.json
@@ -2,7 +2,7 @@
 	{
 		"slug": "interactivity-api",
 		"name": "INTERACTIVITY API",
-		"description": "These examples show the use of the experimental [Interactivity API](https://make.wordpress.org/core/2023/03/30/proposal-the-interactivity-api-a-better-developer-experience-in-building-interactive-blocks/) in Blocks via the [`@wordpress/interactivity` package](https://github.com/WordPress/gutenberg/blob/trunk/packages/interactivity/README.md)"
+		"description": "These examples show the use of the [Interactivity API](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/) in Blocks via the [`@wordpress/interactivity` package](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-interactivity/)"
 	},
 	{
 		"slug": "interactive-block",


### PR DESCRIPTION
The description was outdated, as it stated that the Interactivity API was still experimental and pointed to old links.